### PR TITLE
HIS-46: remove drag/connectability of nodes and reposition search bar

### DIFF
--- a/histree-frontend/src/components/Flow.tsx
+++ b/histree-frontend/src/components/Flow.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import ReactFlow, { Controls, Background, Node, Edge, useReactFlow } from "reactflow";
+import ReactFlow, {
+  Controls,
+  Background,
+  Node,
+  Edge,
+  useReactFlow,
+} from "reactflow";
 import "reactflow/dist/style.css";
 import {
   NodeInfo,
@@ -56,6 +62,9 @@ const dagreToFlowNodes = (graph: graphlib.Graph): Node[] => {
           label: <TreeNodeCard displayName={`${nodeObj.label}`} />,
         },
         position: { x: nodeObj.x, y: nodeObj.y },
+        draggable: false,
+        connectable: false,
+        deletable: false,
       };
       ns.push(flowNode);
     }
@@ -145,21 +154,21 @@ const nodesToDisplay = (
 
 // Converts adjacency list to list of Edges for React Flow rendering.
 const layoutEdges = (adjList: AdjList): Edge[] => {
-	const completeEdges: Edge[] = [];
+  const completeEdges: Edge[] = [];
 
-	Object.keys(adjList).forEach((source) => {
-		adjList[source].forEach((target) => {
-			const edge: Edge = {
-				id: `${source}-${target}`,
-				source: source,
-				target: target,
-				type: "step",
-			};
-			completeEdges.push(edge);
-		});
-	});
+  Object.keys(adjList).forEach((source) => {
+    adjList[source].forEach((target) => {
+      const edge: Edge = {
+        id: `${source}-${target}`,
+        source: source,
+        target: target,
+        type: "step",
+      };
+      completeEdges.push(edge);
+    });
+  });
 
-	return completeEdges;
+  return completeEdges;
 };
 
 const Flow = () => {

--- a/histree-frontend/src/components/general/DepthBox.tsx
+++ b/histree-frontend/src/components/general/DepthBox.tsx
@@ -19,6 +19,7 @@ export const DepthBox = () => {
         defaultValue={depth}
         variant="outlined"
         type="number"
+        label="Tree Depth"
         fullWidth
         onChange={(e) => handleSetDepth(e)}
       />

--- a/histree-frontend/src/components/general/SearchBar.scss
+++ b/histree-frontend/src/components/general/SearchBar.scss
@@ -1,9 +1,9 @@
 .search_container {
-	margin: 1em;
-	width: 35%;
-	height: 10%;
-	position: absolute;
-	z-index: 99;
-	left: 10%;
-	top: 10%;
+  margin: 1em;
+  width: 35%;
+  height: 10%;
+  position: absolute;
+  z-index: 99;
+  left: 1%;
+  top: 2%;
 }


### PR DESCRIPTION
JIRA Link: [HIS-46](https://histree.atlassian.net/browse/HIS-46?atlOrigin=eyJpIjoiMzk1ZDJjN2UzM2Y1NGYzNjhmN2JiOTIzOGM2MDNkNDAiLCJwIjoiaiJ9)

# Description
Fix bug where handles can be dragged out from nodes.
Reposition search bar to top left.