### PR TITLE
His 47 variable tree depth

### DIFF
--- a/histree_backend/README.md
+++ b/histree_backend/README.md
@@ -1,0 +1,8 @@
+## Running Tests
+To execute all the tests, move to the `/data_retrieval` directory and run `python3 -m unittest discover tests/`.
+
+## CLI for Query to JSON Tree
+For a CLI demo of generating the JSON family tree of a person, run `python3 -m data_retrieval.main`.
+
+## Expose API Locally
+To have a working exposed API locally, run `FLASK_APP=histree python3 -m flask run`.

--- a/histree_backend/data_retrieval/README.md
+++ b/histree_backend/data_retrieval/README.md
@@ -1,5 +1,0 @@
-## Running Tests
-To run all the tests, run `python3 -m unittest discover tests/`.
-
-## CLI for Query to JSON Tree
-For a CLI demo of generating the JSON family tree of a person, run `python3 main.py`.

--- a/histree_backend/data_retrieval/tests/test_units.py
+++ b/histree_backend/data_retrieval/tests/test_units.py
@@ -24,8 +24,8 @@ class TestWikiTreeMethods(unittest.TestCase):
 
         for parent in (father, mother):
             if parent not in tree.branches:
-                tree.branches[parent.id] = []
-            tree.branches[parent.id].append(item.entity_id)
+                tree.branches[parent.id] = set()
+            tree.branches[parent.id].add(item.entity_id)
 
     def _create_dummy_children(self, item: WikidataItem, tree: WikiTree, params: List[Dict[str, any]]) -> None:
         for child in params:
@@ -38,8 +38,8 @@ class TestWikiTreeMethods(unittest.TestCase):
             tree.flowers[child_flower.id] = child_flower
 
             if item.entity_id not in tree.branches:
-                tree.branches[item.entity_id] = []
-            tree.branches[item.entity_id].append(
+                tree.branches[item.entity_id] = set()
+            tree.branches[item.entity_id].add(
                 child_flower.id)
 
     @patch("wikitree.tree.WikidataAPI")

--- a/histree_backend/data_retrieval/wikitree/tree.py
+++ b/histree_backend/data_retrieval/wikitree/tree.py
@@ -19,8 +19,8 @@ class WikiSeed:
             tree.grow(parent_flower.id,
                       branch_up=False, branch_down=False)
             if parent_flower.id not in tree.branches:
-                tree.branches[parent_flower.id] = []
-            tree.branches[parent_flower.id].append(
+                tree.branches[parent_flower.id] = set()
+            tree.branches[parent_flower.id].add(
                 item.entity_id)
 
     def branch_down(self, item: WikidataItem, tree: "WikiTree") -> None:
@@ -29,13 +29,13 @@ class WikiSeed:
             item, tree.flowers)
 
         if children_flowers and item.entity_id not in tree.branches:
-            tree.branches[item.entity_id] = []
+            tree.branches[item.entity_id] = set()
 
         # Find petals and parents of each child flower
         for child_flower in children_flowers:
             tree.grow(child_flower.id,
                       branch_up=True, branch_down=False)
-            tree.branches[item.entity_id].append(
+            tree.branches[item.entity_id].add(
                 child_flower.id)
 
 

--- a/histree_backend/data_retrieval/wikitree/tree.py
+++ b/histree_backend/data_retrieval/wikitree/tree.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Dict, List
+from typing import Dict, List, Tuple
 from qwikidata.entity import WikidataItem
 from qwikidata.linked_data_interface import get_entity_dict_from_api
 from .flower import WikiFlower, WikiPetal, WikiStem
@@ -11,7 +11,7 @@ class WikiSeed:
         self.partner_stem = partner_stem
         self.petals = set(petals)
 
-    def branch_up(self, item: WikidataItem, tree: "WikiTree") -> None:
+    def branch_up(self, item: WikidataItem, tree: "WikiTree") -> List[WikiFlower]:
         parent_flowers = self.up_stem.parse(
             item, tree.flowers)
 
@@ -23,7 +23,9 @@ class WikiSeed:
             tree.branches[parent_flower.id].add(
                 item.entity_id)
 
-    def branch_down(self, item: WikidataItem, tree: "WikiTree") -> None:
+        return parent_flowers
+
+    def branch_down(self, item: WikidataItem, tree: "WikiTree") -> List[WikiFlower]:
         # Add children flowers to collection
         children_flowers = self.down_stem.parse(
             item, tree.flowers)
@@ -37,6 +39,8 @@ class WikiSeed:
                       branch_up=True, branch_down=False)
             tree.branches[item.entity_id].add(
                 child_flower.id)
+
+        return children_flowers
 
 
 class WikiAPI:
@@ -65,7 +69,7 @@ class WikiTree:
         self.branches = dict()
         self.api = api
 
-    def grow(self, id: str, branch_up: bool = True, branch_down: bool = True) -> None:
+    def grow(self, id: str, branch_up: bool = True, branch_down: bool = True) -> Tuple[List[WikiFlower], List[WikiFlower]]:
         if id in self.flowers and self.flowers[id].branched_up and self.flowers[id].branched_down:
             return
         item = self.api.get_wikidata_item(id)
@@ -81,12 +85,28 @@ class WikiTree:
             flower.petals = flower_petals
 
         # Branch off from the flower to find immediate nearby flowers
+        flowers_above, flowers_below = None, None
         if branch_up and not flower.branched_up:
-            self.seed.branch_up(item, self)
+            flowers_above = self.seed.branch_up(item, self)
             flower.branched_up = True
         if branch_down and not flower.branched_down:
-            self.seed.branch_down(item, self)
+            flowers_below = self.seed.branch_down(
+                item, self)
             flower.branched_down = True
+
+        return flowers_above, flowers_below
+
+    def grow_levels(self, id: str, branch_up_levels: int, branch_down_levels: int) -> None:
+        above, below = self.grow(
+            id, branch_up_levels > 0, branch_down_levels > 0)
+        if above:
+            for flower in above:
+                self.grow_levels(
+                    flower.id, branch_up_levels - 1, 0)
+        if below:
+            for flower in below:
+                self.grow_levels(
+                    flower.id, 0, branch_down_levels - 1)
 
     def to_json(self) -> Dict[str, any]:
         return {

--- a/histree_backend/data_retrieval/wikitree/tree.py
+++ b/histree_backend/data_retrieval/wikitree/tree.py
@@ -111,5 +111,5 @@ class WikiTree:
     def to_json(self) -> Dict[str, any]:
         return {
             'flowers': [flower.to_json() for flower in self.flowers.values()],
-            'branches': self.branches
+            'branches': {id: list(adj_set) for (id, adj_set) in self.branches.items()}
         }

--- a/histree_backend/histree_query.py
+++ b/histree_backend/histree_query.py
@@ -33,9 +33,9 @@ class HistreeQuery:
         return qid_label_map
 
     @staticmethod
-    def get_tree_from_id(qid: str, seed: WikiSeed=FamilySeed.instance()) -> Dict[str, any]:
+    def get_tree_from_id(qid: str, seed: WikiSeed=FamilySeed.instance(), branch_up_levels: int = 3, branch_down_levels: int = 3) -> Dict[str, any]:
         tree = WikiTree(seed)
-        tree.grow(qid)
+        tree.grow_levels(qid, branch_up_levels, branch_down_levels)
         return tree.to_json()
 
 

--- a/histree_backend/histree_query.py
+++ b/histree_backend/histree_query.py
@@ -33,7 +33,7 @@ class HistreeQuery:
         return qid_label_map
 
     @staticmethod
-    def get_tree_from_id(qid: str, seed: WikiSeed=FamilySeed.instance(), branch_up_levels: int = 3, branch_down_levels: int = 3) -> Dict[str, any]:
+    def get_tree_from_id(qid: str, seed: WikiSeed=FamilySeed.instance(), branch_up_levels: int = 2, branch_down_levels: int = 2) -> Dict[str, any]:
         tree = WikiTree(seed)
         tree.grow_levels(qid, branch_up_levels, branch_down_levels)
         return tree.to_json()


### PR DESCRIPTION
JIRA Link: [HIS-47](https://histree.atlassian.net/browse/HIS-47?atlOrigin=eyJpIjoiMjdiZmI4NTQ2ZWU5NDcxZDlhY2Y1NjViN2ZjOGU5MTYiLCJwIjoiaiJ9)

# Description

## Additions
- Allow variable levels of depth in the returned tree.
  - By default, it's currently set to two levels above and two levels below.
  - Another endpoint could be set up to have the number of levels above and below as parameters.
  - The query times grow exponentially with the number of levels. It may be advantageous to make multiple small queries rather than a single large one to avoid long waiting times for the user.
- Move `README` to the root backend folder and add a note on how to run locally.

## Fixes
- Avoid having duplicate IDs in adjacency lists of the returned JSON tree.