### PR TITLE
His 50 improve tree generation

### DIFF
--- a/histree_backend/data_retrieval/tests/test_units.py
+++ b/histree_backend/data_retrieval/tests/test_units.py
@@ -46,7 +46,7 @@ class TestWikiTreeMethods(unittest.TestCase):
     @patch("wikitree.tree.WikiSeed")
     def test_grow(self, MockSeedClass, MockWikidataAPIClass):
         MockSeedClass.branch_up, MockSeedClass.branch_down = MagicMock(), MagicMock()
-        MockSeedClass.branch_up.side_effect = lambda it, tr: self._create_dummy_parents(it, tr, {
+        MockSeedClass.branch_up.side_effect = lambda it, tr, _: self._create_dummy_parents(it, tr, {
             "father": {
                 "id": "Q0",
                 "petals": dict(),
@@ -65,7 +65,7 @@ class TestWikiTreeMethods(unittest.TestCase):
             "sitelinks": [],
             "type": "item",
         }
-        MockSeedClass.branch_down.side_effect = lambda it, tr: self._create_dummy_children(it, tr, [
+        MockSeedClass.branch_down.side_effect = lambda it, tr, _: self._create_dummy_children(it, tr, [
             {
                 "id": "Q10",
                 "other_parent": "Q3",

--- a/histree_backend/data_retrieval/wikitree/flower.py
+++ b/histree_backend/data_retrieval/wikitree/flower.py
@@ -7,6 +7,7 @@ class WikiFlower:
     def __init__(self, id: str, petals: Dict[str, str]):
         self.id = id
         self.name = ""
+        self.description = ""
         self.petals = petals
         self.branched_up = False
         self.branched_down = False
@@ -17,6 +18,8 @@ class WikiFlower:
             "name": self.name,
             "petals": self.petals
         }
+        if self.description:
+            json_dict["description"] = self.description
         return json_dict
 
 

--- a/histree_backend/data_retrieval/wikitree/tree.py
+++ b/histree_backend/data_retrieval/wikitree/tree.py
@@ -11,13 +11,14 @@ class WikiSeed:
         self.partner_stem = partner_stem
         self.petals = set(petals)
 
-    def branch_up(self, item: WikidataItem, tree: "WikiTree") -> List[WikiFlower]:
+    def branch_up(self, item: WikidataItem, tree: "WikiTree", grow_branched: bool = True) -> List[WikiFlower]:
         parent_flowers = self.up_stem.parse(
             item, tree.flowers)
 
         for parent_flower in parent_flowers:
-            tree.grow(parent_flower.id,
-                      branch_up=False, branch_down=False)
+            if grow_branched:
+                tree.grow(parent_flower.id,
+                          branch_up=False, branch_down=False)
             if parent_flower.id not in tree.branches:
                 tree.branches[parent_flower.id] = set()
             tree.branches[parent_flower.id].add(
@@ -25,7 +26,7 @@ class WikiSeed:
 
         return parent_flowers
 
-    def branch_down(self, item: WikidataItem, tree: "WikiTree") -> List[WikiFlower]:
+    def branch_down(self, item: WikidataItem, tree: "WikiTree", grow_branched: bool = True) -> List[WikiFlower]:
         # Add children flowers to collection
         children_flowers = self.down_stem.parse(
             item, tree.flowers)
@@ -35,8 +36,9 @@ class WikiSeed:
 
         # Find petals and parents of each child flower
         for child_flower in children_flowers:
-            tree.grow(child_flower.id,
-                      branch_up=True, branch_down=False)
+            if grow_branched:
+                tree.grow(child_flower.id,
+                          branch_up=True, branch_down=False)
             tree.branches[item.entity_id].add(
                 child_flower.id)
 
@@ -69,10 +71,11 @@ class WikiTree:
         self.branches = dict()
         self.api = api
 
-    def grow(self, id: str, branch_up: bool = True, branch_down: bool = True) -> Tuple[List[WikiFlower], List[WikiFlower]]:
-        if id in self.flowers and self.flowers[id].branched_up and self.flowers[id].branched_down:
-            return
+    def grow(self, id: str, branch_up: bool = True, branch_down: bool = True, grow_branched: bool = True) -> Tuple[List[WikiFlower], List[WikiFlower]]:
+        if id in self.flowers and (not branch_up or self.flowers[id].branched_up) and (not branch_down or self.flowers[id].branched_down):
+            return None, None
         item = self.api.get_wikidata_item(id)
+
         # Find petals of the flower
         if id not in self.flowers:
             self.flowers[id] = WikiFlower(id, dict())
@@ -87,26 +90,27 @@ class WikiTree:
         # Branch off from the flower to find immediate nearby flowers
         flowers_above, flowers_below = None, None
         if branch_up and not flower.branched_up:
-            flowers_above = self.seed.branch_up(item, self)
+            flowers_above = self.seed.branch_up(
+                item, self, grow_branched)
             flower.branched_up = True
         if branch_down and not flower.branched_down:
             flowers_below = self.seed.branch_down(
-                item, self)
+                item, self, grow_branched)
             flower.branched_down = True
-
         return flowers_above, flowers_below
 
     def grow_levels(self, id: str, branch_up_levels: int, branch_down_levels: int) -> None:
         above, below = self.grow(
-            id, branch_up_levels > 0, branch_down_levels > 0)
+            id, branch_up_levels > 0, branch_down_levels > 0, branch_up_levels == branch_down_levels == 0)
         if above:
             for flower in above:
                 self.grow_levels(
                     flower.id, branch_up_levels - 1, 0)
         if below:
             for flower in below:
+                # Grow upwards once to find other parent.
                 self.grow_levels(
-                    flower.id, 0, branch_down_levels - 1)
+                    flower.id, 1, branch_down_levels - 1)
 
     def to_json(self) -> Dict[str, any]:
         return {

--- a/histree_backend/data_retrieval/wikitree/tree.py
+++ b/histree_backend/data_retrieval/wikitree/tree.py
@@ -80,6 +80,7 @@ class WikiTree:
         if id not in self.flowers:
             self.flowers[id] = WikiFlower(id, dict())
             self.flowers[id].name = item.get_label()
+            self.flowers[id].description = item.get_description()
         flower = self.flowers[id]
 
         if not flower.petals:

--- a/histree_backend/data_retrieval/wikitree_instance/familytree/petals.py
+++ b/histree_backend/data_retrieval/wikitree_instance/familytree/petals.py
@@ -1,7 +1,6 @@
 from qwikidata.entity import WikidataItem
 from data_retrieval.wikitree.flower import WikiPetal
 from data_retrieval.wikitree_instance.familytree.property import PROPERTY_MAP
-import hashlib
 
 
 class NamePetal(WikiPetal):

--- a/histree_backend/data_retrieval/wikitree_instance/familytree/petals.py
+++ b/histree_backend/data_retrieval/wikitree_instance/familytree/petals.py
@@ -1,6 +1,7 @@
 from qwikidata.entity import WikidataItem
 from data_retrieval.wikitree.flower import WikiPetal
 from data_retrieval.wikitree_instance.familytree.property import PROPERTY_MAP
+import hashlib
 
 
 class NamePetal(WikiPetal):
@@ -75,3 +76,22 @@ class BirthNamePetal(WikiPetal):
         if not birth_names:
             return self.undefined
         return birth_names[0]
+
+
+class ImagePetal(WikiPetal):
+    URL_PREFIX = "https://en.wikipedia.org/wiki/Special:FilePath/"
+
+    def __init__(self):
+        label = "image"
+        super().__init__(
+            PROPERTY_MAP["petals"][label], label)
+
+    def to_wikimedia_url(self, image: str) -> str:
+        return self.URL_PREFIX + image.replace(' ', '_')
+
+    def parse(self, item: WikidataItem) -> str:
+        images = [claim.mainsnak.datavalue.value
+                  for claim in item.get_claim_group(self.id)._claims if claim.mainsnak.datavalue]
+        if not images:
+            return self.undefined
+        return self.to_wikimedia_url(images[0])

--- a/histree_backend/data_retrieval/wikitree_instance/familytree/property.py
+++ b/histree_backend/data_retrieval/wikitree_instance/familytree/property.py
@@ -3,6 +3,7 @@ PROPERTY_MAP = {
         "birth name": "P1477",
         "date of birth": "P569",
         "date of death": "P570",
+        "image": "P18",
         "sex/gender": "P21"
     },
     "stems": {

--- a/histree_backend/data_retrieval/wikitree_instance/familytree/seed.py
+++ b/histree_backend/data_retrieval/wikitree_instance/familytree/seed.py
@@ -17,7 +17,8 @@ class FamilySeed(WikiSeed):
                 GenderPetal.instance(),
                 BirthDatePetal.instance(),
                 DeathDatePetal.instance(),
-                BirthNamePetal.instance()
+                BirthNamePetal.instance(),
+                ImagePetal.instance()
             ]
         )
 

--- a/histree_backend/histree.py
+++ b/histree_backend/histree.py
@@ -1,5 +1,4 @@
-from flask import Flask, render_template, jsonify
-from typing import Dict
+from flask import Flask, render_template, jsonify, request
 
 from histree_query import HistreeQuery
 
@@ -14,7 +13,8 @@ def greet():
 # Pass in a name and return a dictionary of potential matches names to Wiki IDs
 @app.route('/find_matches/<name>')
 def find_matches(name: str):
-    response = jsonify(HistreeQuery.search_matching_names(name))
+    response = jsonify(
+        HistreeQuery.search_matching_names(name))
     response.headers.add("Access-Control-Allow-Origin", "*")
     return response
 
@@ -22,6 +22,11 @@ def find_matches(name: str):
 # Pass in a Wiki ID and return a json of all their relevant data
 @app.route('/person_info/<qid>')
 def person_info(qid):
-    response = jsonify(HistreeQuery.get_tree_from_id(qid))
+    depth_up = request.args.get(
+        'depth_up', default=2, type=int)
+    depth_down = request.args.get(
+        'depth_down', default=2, type=int)
+    response = jsonify(HistreeQuery.get_tree_from_id(
+        qid, branch_up_levels=depth_up, branch_down_levels=depth_down))
     response.headers.add("Access-Control-Allow-Origin", "*")
     return response

--- a/histree_backend/histree.py
+++ b/histree_backend/histree.py
@@ -1,5 +1,5 @@
-from flask import Flask, render_template, jsonify, request
-
+from flask import Flask, render_template, jsonify, request, Response
+from json import JSONDecodeError
 from histree_query import HistreeQuery
 
 app = Flask(__name__)
@@ -13,8 +13,11 @@ def greet():
 # Pass in a name and return a dictionary of potential matches names to Wiki IDs
 @app.route('/find_matches/<name>')
 def find_matches(name: str):
-    response = jsonify(
-        HistreeQuery.search_matching_names(name))
+    try:
+        response = jsonify(
+            HistreeQuery.search_matching_names(name))
+    except JSONDecodeError:
+        response = Response()
     response.headers.add("Access-Control-Allow-Origin", "*")
     return response
 
@@ -23,10 +26,13 @@ def find_matches(name: str):
 @app.route('/person_info/<qid>')
 def person_info(qid):
     depth_up = request.args.get(
-        'depth_up', default=2, type=int)
+        'depth_up', default=1, type=int)
     depth_down = request.args.get(
-        'depth_down', default=2, type=int)
-    response = jsonify(HistreeQuery.get_tree_from_id(
-        qid, branch_up_levels=depth_up, branch_down_levels=depth_down))
+        'depth_down', default=1, type=int)
+    try:
+        response = jsonify(HistreeQuery.get_tree_from_id(
+            qid, branch_up_levels=depth_up, branch_down_levels=depth_down))
+    except JSONDecodeError:
+        response = Response()
     response.headers.add("Access-Control-Allow-Origin", "*")
     return response

--- a/histree_backend/histree_query.py
+++ b/histree_backend/histree_query.py
@@ -9,9 +9,10 @@ class HistreeQuery:
     @staticmethod
     def processQueryString(name: str) -> str:
         # standardises the capitalisation of query string to be consistent with Wikidata expectations
-        
+
         prepos = {"the", "of", "in", "and"}
-        isRomanNumeral = lambda w : bool(re.search(r"^M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$",w))
+        def isRomanNumeral(w): return bool(re.search(
+            r"^M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$", w))
 
         words = name.split()
         for i in range(len(words)):
@@ -21,66 +22,57 @@ class HistreeQuery:
                     words[i] = word.upper()
                 else:
                     words[i] = word.capitalize()
-        
+
         return " ".join(words)
 
     @staticmethod
-    def search_matching_names(name: str, instance_of: str = "Q5", language: str = "en") -> Dict[str, str]:
+    def search_matching_names(name: str, instance_of: str = "Q5", language: str = "en") -> Dict[int, Dict[str, str]]:
         # Check if name has been queried before in db and return if so
         input = HistreeQuery.processQueryString(name)
         # Otherwise, query wikidata directly
         query = f'''
-            SELECT distinct ?item ?itemLabel ?itemAltLabel WHERE{{  
-                ?item ?label "{input}"@{language}.  
-                ?item wdt:P31 wd:{instance_of} .
-                ?article schema:about ?item .
-                ?article schema:inLanguage "{language}" .
-                ?article schema:isPartOf <https://en.wikipedia.org/>.	
-                SERVICE wikibase:label {{ bd:serviceParam wikibase:language "{language}". }}    
-            }}
+            SELECT ?item ?label ?description WHERE {{
+                SERVICE wikibase:mwapi {{
+                    bd:serviceParam wikibase:api "EntitySearch" .
+                    bd:serviceParam wikibase:endpoint "www.wikidata.org" .
+                    bd:serviceParam mwapi:search "{name}" .
+                    bd:serviceParam mwapi:language "{language}" .
+                    ?item wikibase:apiOutputItem mwapi:item .
+                    ?num wikibase:apiOrdinal true .
+                }}
+                ?item wdt:P31 wd:{instance_of};
+                        rdfs:label ?label;
+                        schema:description ?description.
+                FILTER(REGEX(?label, "^{name}"))
+                FILTER(LANG(?label) = "{language}")
+                FILTER(LANG(?description) = "{language}")
+            }} ORDER BY ASC(?num) LIMIT 10
         '''
 
         res = return_sparql_query_results(query)
-        
+
         qid_label_map = dict()
-        unique_labels = set()
 
-        for row in res["results"]["bindings"]:
-            qid = row["item"]["value"].split('/')[-1]
-            label = row["itemLabel"]["value"]
-            unique_label = True
-
-            
-            # Generate a unique label for each query item by looking at list of
-            # alternate names. If no unique alternative labels exist for the item,
-            # it is not included in the results dictionary.
-            if label in unique_labels:
-                unique_label = False
-                if row.get("itemAltLabel") != None:
-                    for l in [s.strip() for s in row["itemAltLabel"]["value"].split(',')]:
-                        if l not in unique_labels:
-                            unique_labels.add(l)
-                            unique_label = True
-                            label = l
-                            break
-            else:
-                unique_labels.add(label)
-
-            if unique_label :
-                qid_label_map[qid] = label
+        for (i, row) in enumerate(res["results"]["bindings"]):
+            qid_label_map[i] = {
+                "id": row["item"]["value"].split('/')[-1],
+                "label": row["label"]["value"],
+                "description": row["description"]["value"]
+            }
 
         return qid_label_map
 
     @staticmethod
-    def get_tree_from_id(qid: str, seed: WikiSeed=FamilySeed.instance(), branch_up_levels: int = 2, branch_down_levels: int = 2) -> Dict[str, any]:
+    def get_tree_from_id(qid: str, seed: WikiSeed = FamilySeed.instance(), branch_up_levels: int = 2, branch_down_levels: int = 2) -> Dict[str, any]:
         tree = WikiTree(seed)
-        tree.grow_levels(qid, branch_up_levels, branch_down_levels)
+        tree.grow_levels(
+            qid, branch_up_levels, branch_down_levels)
         return tree.to_json()
-
 
     def _query_cli() -> None:
         name = input("Name to Query: ")
-        matches = list(HistreeQuery.search_matching_names(name).items())
+        matches = list(
+            HistreeQuery.search_matching_names(name).items())
 
         print("Potential matches for Query: ")
         for (i, label) in enumerate(matches):
@@ -92,5 +84,3 @@ class HistreeQuery:
 
         tree_json = HistreeQuery.get_tree_from_id(qid)
         print(tree_json)
-
-    


### PR DESCRIPTION
JIRA Link: [HIS-50](https://histree.atlassian.net/browse/HIS-50?atlOrigin=eyJpIjoiYmQ3YmY1OTVmZTA2NGI4ZGE3Y2JkZDkwNTkwMmYyMzgiLCJwIjoiaiJ9)

# Description

## Additions
- Add image link as a petal.
  - (e.g. [`"https://en.wikipedia.org/wiki/Special:FilePath/Queen_Elizabeth_II_in_March_2015.jpg"`](https://en.wikipedia.org/wiki/Special:FilePath/Queen_Elizabeth_II_in_March_2015.jpg))
- Add descriptions to JSON output.
  - (e.g. `"Queen of the United Kingdom from 1952 to 2022"`)
- Add the ability to control tree generation when making requests to the `/person_info` endpoint.
  - `depth_up` and `depth_down` control the depth of traversal in the upward and downward directions respectively.
  - If not specified in request parameters, they default to one level up and one level down.
  - (e.g. `http://127.0.0.1:5000/person_info/Q9682?depth_up=3&depth_down=1`)
  - Note: using a depth of zero in both directions will result in just querying a single person's information.

## Fixes
- Avoid redundant queries during tree construction.
  - Tree construction should now be at least twice as fast.
- Catch JSON decode error from `qwikidata` library function.
  - This should fix the CORS error when typing too fast/making too many requests to WikiData at once. 
- Make queries faster and get richer results.
  - Queries take no more than a second now.
  - Results are sorted based on relevance and contain descriptions for disambiguation purposes.
  - An example result when searching for `"Elizab"`:
  ```
  {
    "0": {
      "description": "Queen of the United Kingdom from 1952 to 2022",
      "id": "Q9682",
      "label": "Elizabeth II"
    },
    "1": {
      "description": "Queen of England and Ireland from 1558 to 1603",
      "id": "Q7207",
      "label": "Elizabeth I of England"
    },
    "2": {
      "description": "Australian-born American biological researcher",
      "id": "Q26321",
      "label": "Elizabeth Blackburn"
    },
    "3": {
      "description": "Christian saint",
      "id": "Q159862",
      "label": "Elizabeth of Hungary"
    },
    "4": {
      "description": "British-American actress (1932-2011)",
      "id": "Q34851",
      "label": "Elizabeth Taylor"
    },
    "5": {
      "description": "English poet, author",
      "id": "Q228494",
      "label": "Elizabeth Barrett Browning"
    },
    "6": {
      "description": "American politician (born 1949)",
      "id": "Q434706",
      "label": "Elizabeth Warren"
    },
    "7": {
      "description": "Empress of Russia (1741–1762)",
      "id": "Q130752",
      "label": "Elizabeth of Russia"
    },
    "8": {
      "description": "American cognitive psychologist",
      "id": "Q262154",
      "label": "Elizabeth Loftus"
    },
    "9": {
      "description": "American actress and producer",
      "id": "Q219373",
      "label": "Elizabeth Banks"
    }
  }
  ```
  - Note: Front-end should change how they parse the response to accommodate for this new format.
