### PR TITLE
His 54 finer grained name queries

### DIFF
--- a/histree_backend/data_retrieval/query/builder.py
+++ b/histree_backend/data_retrieval/query/builder.py
@@ -1,0 +1,66 @@
+class QueryBuilder:
+    def __init__(self):
+        self.language = "en"
+        self.predicate = ""
+        self.limit = None
+        self.headers = dict()
+        self.filters = dict()
+
+    def build(self) -> str:
+        header_selections = " ".join(
+            f"(SAMPLE(?{header} as ?{header}_))" if config["sample"] else f"?{header}"
+            for (header, config) in self.headers.items()
+        )
+        header_bindings = " ".join(
+            ("OPTIONAL{%s}" if config["optional"] else "%s")
+            % f"?item wdt:{config['id']} ?{header}."
+            for (header, config) in self.headers.items()
+        )
+        header_access = " ".join(
+            f"?{header}" + ("_" if config["sample"] else "")
+            for (header, config) in self.headers.items()
+        )
+        filtering = ""
+        if self.filters:
+            for (property, values) in self.filters.items():
+                filtering += f"VALUES ?filter_{property} {{ {' '.join([f'wd:{v}' for v in values])} }}."
+                filtering += (
+                    f"FILTER NOT EXISTS {{?item wdt:{property} ?filter_{property}.}}."
+                )
+        return f"""
+            SELECT ?item ?label ?description {header_selections}
+            WHERE {{
+              ?item {self.predicate}
+                rdfs:label ?label;
+                schema:description ?description.
+              {header_bindings}
+              {filtering}
+              FILTER(lang(?label) = "{self.language}" && lang(?description) = "{self.language}")
+            }}
+            GROUP BY ?item ?label ?description {header_access}
+            {f"LIMIT {self.limit}" if self.limit is not None else ""}
+        """
+
+    def with_limit(self, limit: int) -> "QueryBuilder":
+        self.limit = limit
+        return self
+
+    def with_property(self, property: str, value: str) -> "QueryBuilder":
+        self.predicate += f"wdt:{property} wd:{value};"
+        return self
+
+    def with_instance(self, instance: str) -> "QueryBuilder":
+        return self.with_property("P31", instance)
+
+    def under_class(self, cls: str) -> "QueryBuilder":
+        self.predicate += f"p:P31/ps:P31/wdt:P279* wd:{cls};"
+        return self
+
+    def without_property(self, property: str, value: str) -> "QueryBuilder":
+        if property not in self.filters:
+            self.filters[property] = []
+        self.filters[property].append(value)
+        return self
+
+    def without_instance(self, instance: str) -> "QueryBuilder":
+        return self.without_property("P31", instance)

--- a/histree_backend/data_retrieval/query/builder.py
+++ b/histree_backend/data_retrieval/query/builder.py
@@ -1,11 +1,16 @@
+from typing import Dict
+
+
 class SPARQLBuilder:
-    def __init__(self):
-        self.language = "en"
+    def __init__(
+        self, headers: Dict[str, Dict[str, any]] = dict(), language: str = "en"
+    ):
+        self.language = language
         self.predicate = ""
         self.limit = None
         self.order_by = ""
         self.other = ""
-        self.headers = dict()
+        self.headers = headers
         self.filters = dict()
         self.other_filters = ""
 
@@ -33,14 +38,14 @@ class SPARQLBuilder:
         return f"""
             SELECT ?item ?label ?description {header_selections}
             WHERE {{
-              {self.other}
-              ?item {self.predicate}
-                rdfs:label ?label;
-                schema:description ?description.
-              {header_bindings}
-              {filtering}
-              {self.other_filters}
-              FILTER(lang(?label) = "{self.language}" && lang(?description) = "{self.language}")
+                {self.other}
+                ?item {self.predicate}
+                    rdfs:label ?label;
+                    schema:description ?description.
+                {header_bindings}
+                {filtering}
+                {self.other_filters}
+                FILTER(lang(?label) = "{self.language}" && lang(?description) = "{self.language}")
             }}
             GROUP BY ?item ?label ?description {header_access}
             {self.order_by}

--- a/histree_backend/data_retrieval/query/name_query.py
+++ b/histree_backend/data_retrieval/query/name_query.py
@@ -1,20 +1,23 @@
+from typing import Dict
 from .builder import SPARQLBuilder
 
 
 class NameQueryBuilder(SPARQLBuilder):
-    def __init__(self):
-        super().__init__()
+    def __init__(
+        self, language: str = "en", headers: Dict[str, Dict[str, any]] = dict()
+    ):
+        super().__init__(language=language, headers=headers)
 
     def with_name(self, name: str) -> "NameQueryBuilder":
         self.other = f"""
-            SERVICE wikibase:mwapi {{
-                bd:serviceParam wikibase:api "EntitySearch" .
-                bd:serviceParam wikibase:endpoint "www.wikidata.org" .
-                bd:serviceParam mwapi:search "{name}" .
-                bd:serviceParam mwapi:language "{self.language}" .
-                ?item wikibase:apiOutputItem mwapi:item .
-                ?num wikibase:apiOrdinal true .
-            }}
+                SERVICE wikibase:mwapi {{
+                    bd:serviceParam wikibase:api "EntitySearch" .
+                    bd:serviceParam wikibase:endpoint "www.wikidata.org" .
+                    bd:serviceParam mwapi:search "{name}" .
+                    bd:serviceParam mwapi:language "{self.language}" .
+                    ?item wikibase:apiOutputItem mwapi:item .
+                    ?num wikibase:apiOrdinal true .
+                }}
         """
         return self
 

--- a/histree_backend/data_retrieval/query/name_query.py
+++ b/histree_backend/data_retrieval/query/name_query.py
@@ -1,0 +1,27 @@
+from .builder import SPARQLBuilder
+
+
+class NameQueryBuilder(SPARQLBuilder):
+    def __init__(self):
+        super().__init__()
+
+    def with_name(self, name: str) -> "NameQueryBuilder":
+        self.other = f"""
+            SERVICE wikibase:mwapi {{
+                bd:serviceParam wikibase:api "EntitySearch" .
+                bd:serviceParam wikibase:endpoint "www.wikidata.org" .
+                bd:serviceParam mwapi:search "{name}" .
+                bd:serviceParam mwapi:language "{self.language}" .
+                ?item wikibase:apiOutputItem mwapi:item .
+                ?num wikibase:apiOrdinal true .
+            }}
+        """
+        return self
+
+    def starts_with(self, match: str) -> "NameQueryBuilder":
+        self.other_filters += f'FILTER(REGEX(?item, "^{match}")) '
+        return self
+
+    def matches_regex(self, expr: str) -> "NameQueryBuilder":
+        self.other_filters += f'FILTER(REGEX(?item, "{expr}")) '
+        return self

--- a/histree_backend/data_retrieval/tests/test_units.py
+++ b/histree_backend/data_retrieval/tests/test_units.py
@@ -2,20 +2,26 @@ from typing import Dict, List
 import unittest
 from unittest.mock import patch, MagicMock
 from qwikidata.entity import WikidataItem
+from query.builder import SPARQLBuilder
+from query.name_query import NameQueryBuilder
 from wikitree.flower import WikiFlower
 from wikitree.tree import WikiTree
 
 
 class TestWikiTreeMethods(unittest.TestCase):
-    def _create_dummy_parents(self, item: WikidataItem, tree: WikiTree, params: Dict[str, any]) -> None:
-        tree.grow(params["father"]["id"],
-                  branch_up=False, branch_down=False)
-        tree.grow(params["mother"]["id"],
-                  branch_up=False, branch_down=False)
-        self.assertTrue(params["father"]["id"] in tree.flowers,
-                        msg="Father is not stored in WikiTree.")
-        self.assertTrue(params["mother"]["id"] in tree.flowers,
-                        msg="Mother is not stored in WikiTree.")
+    def _create_dummy_parents(
+        self, item: WikidataItem, tree: WikiTree, params: Dict[str, any]
+    ) -> None:
+        tree.grow(params["father"]["id"], branch_up=False, branch_down=False)
+        tree.grow(params["mother"]["id"], branch_up=False, branch_down=False)
+        self.assertTrue(
+            params["father"]["id"] in tree.flowers,
+            msg="Father is not stored in WikiTree.",
+        )
+        self.assertTrue(
+            params["mother"]["id"] in tree.flowers,
+            msg="Mother is not stored in WikiTree.",
+        )
 
         father = tree.flowers[params["father"]["id"]]
         mother = tree.flowers[params["mother"]["id"]]
@@ -27,35 +33,42 @@ class TestWikiTreeMethods(unittest.TestCase):
                 tree.branches[parent.id] = set()
             tree.branches[parent.id].add(item.entity_id)
 
-    def _create_dummy_children(self, item: WikidataItem, tree: WikiTree, params: List[Dict[str, any]]) -> None:
+    def _create_dummy_children(
+        self, item: WikidataItem, tree: WikiTree, params: List[Dict[str, any]]
+    ) -> None:
         for child in params:
-            child_flower = WikiFlower(
-                child["id"], child["petals"])
-            tree.grow(child["other_parent"],
-                      branch_up=False, branch_down=False)
-            self.assertTrue(child["other_parent"] in tree.flowers,
-                            msg="Spouse is not stored in WikiTree.")
+            child_flower = WikiFlower(child["id"], child["petals"])
+            tree.grow(child["other_parent"], branch_up=False, branch_down=False)
+            self.assertTrue(
+                child["other_parent"] in tree.flowers,
+                msg="Spouse is not stored in WikiTree.",
+            )
             tree.flowers[child_flower.id] = child_flower
 
             if item.entity_id not in tree.branches:
                 tree.branches[item.entity_id] = set()
-            tree.branches[item.entity_id].add(
-                child_flower.id)
+            tree.branches[item.entity_id].add(child_flower.id)
 
     @patch("wikitree.tree.WikidataAPI")
     @patch("wikitree.tree.WikiSeed")
     def test_grow(self, MockSeedClass, MockWikidataAPIClass):
         MockSeedClass.branch_up, MockSeedClass.branch_down = MagicMock(), MagicMock()
-        MockSeedClass.branch_up.side_effect = lambda it, tr, _: self._create_dummy_parents(it, tr, {
-            "father": {
-                "id": "Q0",
-                "petals": dict(),
-            },
-            "mother": {
-                "id": "Q1",
-                "petals": dict(),
-            }
-        })
+        MockSeedClass.branch_up.side_effect = (
+            lambda it, tr, _: self._create_dummy_parents(
+                it,
+                tr,
+                {
+                    "father": {
+                        "id": "Q0",
+                        "petals": dict(),
+                    },
+                    "mother": {
+                        "id": "Q1",
+                        "petals": dict(),
+                    },
+                },
+            )
+        )
         mock_flower_data = {
             "aliases": [],
             "claims": [],
@@ -65,29 +78,29 @@ class TestWikiTreeMethods(unittest.TestCase):
             "sitelinks": [],
             "type": "item",
         }
-        MockSeedClass.branch_down.side_effect = lambda it, tr, _: self._create_dummy_children(it, tr, [
-            {
-                "id": "Q10",
-                "other_parent": "Q3",
-                "petals": dict()
-            },
-            {
-                "id": "Q11",
-                "other_parent": "Q4",
-                "petals": dict()
-            }
-        ])
+        MockSeedClass.branch_down.side_effect = (
+            lambda it, tr, _: self._create_dummy_children(
+                it,
+                tr,
+                [
+                    {"id": "Q10", "other_parent": "Q3", "petals": dict()},
+                    {"id": "Q11", "other_parent": "Q4", "petals": dict()},
+                ],
+            )
+        )
 
         def mock_flower_data(id: str) -> WikidataItem:
-            return WikidataItem({
-                "aliases": [],
-                "claims": [],
-                "descriptions": "",
-                "id": id,
-                "labels": {"en": {"language": "en", "value": "name"}},
-                "sitelinks": [],
-                "type": "item",
-            })
+            return WikidataItem(
+                {
+                    "aliases": [],
+                    "claims": [],
+                    "descriptions": "",
+                    "id": id,
+                    "labels": {"en": {"language": "en", "value": "name"}},
+                    "sitelinks": [],
+                    "type": "item",
+                }
+            )
 
         MockWikidataAPIClass.get_wikidata_item.side_effect = mock_flower_data
 
@@ -95,92 +108,156 @@ class TestWikiTreeMethods(unittest.TestCase):
         tree.grow("Q2")
 
         # Flower is correctly stored in the WikiTree
-        self.assertTrue("Q2" in tree.flowers,
-                        msg="Flower is not stored in the WikiTree.")
         self.assertTrue(
-            tree.flowers["Q2"].name == "name", msg="Flower has unexpected name.")
+            "Q2" in tree.flowers, msg="Flower is not stored in the WikiTree."
+        )
+        self.assertTrue(
+            tree.flowers["Q2"].name == "name", msg="Flower has unexpected name."
+        )
         flower = tree.flowers["Q2"]
 
         # Parents are correctly stored in the WikiTree
         MockSeedClass.branch_up.assert_called_once()
-        self.assertTrue("Q1" in tree.branches and "Q2" in tree.branches,
-                        msg="Parents are not stored in the WikiTree.")
+        self.assertTrue(
+            "Q1" in tree.branches and "Q2" in tree.branches,
+            msg="Parents are not stored in the WikiTree.",
+        )
 
-        self.assertTrue("Q0" in tree.flowers,
-                        msg="Father is not stored in the WikiTree")
-        self.assertTrue("Q1" in tree.flowers,
-                        msg="Mother is not stored in the WikiTree.")
-        self.assertTrue(flower.id in tree.branches["Q0"] and flower.id in tree.branches["Q1"],
-                        msg="Incorrect parents assigned to flower.")
+        self.assertTrue(
+            "Q0" in tree.flowers, msg="Father is not stored in the WikiTree"
+        )
+        self.assertTrue(
+            "Q1" in tree.flowers, msg="Mother is not stored in the WikiTree."
+        )
+        self.assertTrue(
+            flower.id in tree.branches["Q0"] and flower.id in tree.branches["Q1"],
+            msg="Incorrect parents assigned to flower.",
+        )
 
         # Children are correctly stored in the WikiTree
         MockSeedClass.branch_down.assert_called_once()
         for child_id in ("Q10", "Q11"):
-            self.assertTrue(child_id in tree.flowers,
-                            msg="Child is not stored in the WikiTree.")
-            self.assertTrue(child_id in tree.branches[flower.id],
-                            msg="Flower is not assigned as parent of child.")
+            self.assertTrue(
+                child_id in tree.flowers, msg="Child is not stored in the WikiTree."
+            )
+            self.assertTrue(
+                child_id in tree.branches[flower.id],
+                msg="Flower is not assigned as parent of child.",
+            )
 
         # Spouses are correctly stored in the WikiTree
         for spouse_id in ("Q3", "Q4"):
-            self.assertTrue(spouse_id in tree.flowers,
-                            msg="Spouse is not stored in the WikiTree.")
+            self.assertTrue(
+                spouse_id in tree.flowers, msg="Spouse is not stored in the WikiTree."
+            )
 
     @patch("wikitree.tree.WikidataAPI")
     @patch("wikitree.tree.WikiSeed")
     def test_to_json(self, MockSeedClass, MockWikidataAPIClass):
-        tree = WikiTree(MockSeedClass(),
-                        MockWikidataAPIClass())
+        tree = WikiTree(MockSeedClass(), MockWikidataAPIClass())
 
-        father_petals = {"dob": "1968-10-20",
-                         "metadata": "father_data"}
+        father_petals = {"dob": "1968-10-20", "metadata": "father_data"}
         father_flower = WikiFlower("Q0", father_petals)
         father_flower.name = "father"
 
-        mother_petals = {"dob": "1967-08-08",
-                         "metadata": "mother_data"}
+        mother_petals = {"dob": "1967-08-08", "metadata": "mother_data"}
         mother_flower = WikiFlower("Q1", mother_petals)
         mother_flower.name = "mother"
 
-        child_petals = {"dob": "2000-01-02",
-                        "metadata": "child_data"}
+        child_petals = {"dob": "2000-01-02", "metadata": "child_data"}
         child_flower = WikiFlower("Q2", child_petals)
         child_flower.name = "child"
 
-        tree.flowers = {flower.id: flower for flower in (
-            father_flower, mother_flower, child_flower)}
-        tree.branches = {flower.id: [child_flower.id] for flower in (
-            father_flower, mother_flower)}
+        tree.flowers = {
+            flower.id: flower for flower in (father_flower, mother_flower, child_flower)
+        }
+        tree.branches = {
+            flower.id: [child_flower.id] for flower in (father_flower, mother_flower)
+        }
 
-        self.assertEqual(tree.to_json(), {
-            "flowers": [
-                {
-                    "id": "Q0",
-                    "name": "father",
-                    "petals": {
-                        "dob": "1968-10-20",
-                        "metadata": "father_data"
+        self.assertEqual(
+            tree.to_json(),
+            {
+                "flowers": [
+                    {
+                        "id": "Q0",
+                        "name": "father",
+                        "petals": {"dob": "1968-10-20", "metadata": "father_data"},
+                    },
+                    {
+                        "id": "Q1",
+                        "name": "mother",
+                        "petals": {"dob": "1967-08-08", "metadata": "mother_data"},
+                    },
+                    {
+                        "id": "Q2",
+                        "name": "child",
+                        "petals": {"dob": "2000-01-02", "metadata": "child_data"},
+                    },
+                ],
+                "branches": {"Q0": ["Q2"], "Q1": ["Q2"]},
+            },
+            msg="JSON representation of WikiTree does not meet expected.",
+        )
+
+
+class TestQueryBuilder(unittest.TestCase):
+    # Remove indents and empty lines (wc do not affect queries) for consistency
+    def _remove_indent_and_newlines(self, query: str):
+        return "\n".join(line.strip() for line in query.split("\n") if line.strip())
+
+    def test_build(self):
+        query = SPARQLBuilder().with_instance("Q5").with_limit(10).build()
+
+        self.assertEqual(
+            self._remove_indent_and_newlines(query),
+            self._remove_indent_and_newlines(
+                """
+                SELECT ?item ?label ?description 
+                WHERE {
+                    ?item wdt:P31 wd:Q5;
+                        rdfs:label ?label;
+                        schema:description ?description.
+                    FILTER(lang(?label) = "en" && lang(?description) = "en")
+                }
+                GROUP BY ?item ?label ?description
+                LIMIT 10
+                """
+            ),
+            msg="Incorrect SPARQL query built.",
+        )
+
+    def test_name_search(self):
+        query = (
+            NameQueryBuilder(language="es")
+            .under_class("Q178885")
+            .with_name("Zeus")
+            .ordered_by("?num")
+            .build()
+        )
+        self.maxDiff = None
+        self.assertEqual(
+            self._remove_indent_and_newlines(query),
+            self._remove_indent_and_newlines(
+                """
+                SELECT ?item ?label ?description 
+                WHERE {
+                    SERVICE wikibase:mwapi {
+                        bd:serviceParam wikibase:api "EntitySearch" .
+                        bd:serviceParam wikibase:endpoint "www.wikidata.org" .
+                        bd:serviceParam mwapi:search "Zeus" .
+                        bd:serviceParam mwapi:language "es" .
+                        ?item wikibase:apiOutputItem mwapi:item .
+                        ?num wikibase:apiOrdinal true .
                     }
-                },
-                {
-                    "id": "Q1",
-                    "name": "mother",
-                    "petals": {
-                        "dob": "1967-08-08",
-                        "metadata": "mother_data"
-                    }
-                },
-                {
-                    "id": "Q2",
-                    "name": "child",
-                    "petals": {
-                        "dob": "2000-01-02",
-                        "metadata": "child_data"
-                    }
-                },
-            ],
-            "branches": {
-                "Q0": ["Q2"],
-                "Q1": ["Q2"]
-            }
-        }, msg="JSON representation of WikiTree does not meet expected.")
+                    ?item p:P31/ps:P31/wdt:P279* wd:Q178885;
+                        rdfs:label ?label;
+                        schema:description ?description.
+                    FILTER(lang(?label) = "es" && lang(?description) = "es")
+                }
+                GROUP BY ?item ?label ?description
+                ORDER BY ASC(?num)
+                """
+            ),
+            msg="Incorrect name query built.",
+        )

--- a/histree_backend/histree_query.py
+++ b/histree_backend/histree_query.py
@@ -1,5 +1,6 @@
 import re
 from typing import Dict
+from data_retrieval.query.name_query import NameQueryBuilder
 from data_retrieval.wikitree.tree import WikiSeed, WikiTree
 from data_retrieval.wikitree_instance.familytree.seed import FamilySeed
 from qwikidata.sparql import return_sparql_query_results
@@ -11,8 +12,13 @@ class HistreeQuery:
         # standardises the capitalisation of query string to be consistent with Wikidata expectations
 
         prepos = {"the", "of", "in", "and"}
-        def isRomanNumeral(w): return bool(re.search(
-            r"^M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$", w))
+
+        def isRomanNumeral(w):
+            return bool(
+                re.search(
+                    r"^M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$", w
+                )
+            )
 
         words = name.split()
         for i in range(len(words)):
@@ -26,28 +32,20 @@ class HistreeQuery:
         return " ".join(words)
 
     @staticmethod
-    def search_matching_names(name: str, instance_of: str = "Q5", language: str = "en") -> Dict[int, Dict[str, str]]:
+    def search_matching_names(
+        name: str, instance: str = "Q5", language: str = "en"
+    ) -> Dict[int, Dict[str, str]]:
         # Check if name has been queried before in db and return if so
-        input = HistreeQuery.processQueryString(name)
+
         # Otherwise, query wikidata directly
-        query = f'''
-            SELECT ?item ?label ?description WHERE {{
-                SERVICE wikibase:mwapi {{
-                    bd:serviceParam wikibase:api "EntitySearch" .
-                    bd:serviceParam wikibase:endpoint "www.wikidata.org" .
-                    bd:serviceParam mwapi:search "{name}" .
-                    bd:serviceParam mwapi:language "{language}" .
-                    ?item wikibase:apiOutputItem mwapi:item .
-                    ?num wikibase:apiOrdinal true .
-                }}
-                ?item wdt:P31 wd:{instance_of};
-                        rdfs:label ?label;
-                        schema:description ?description.
-                FILTER(REGEX(?label, "^{name}"))
-                FILTER(LANG(?label) = "{language}")
-                FILTER(LANG(?description) = "{language}")
-            }} ORDER BY ASC(?num) LIMIT 10
-        '''
+        query = (
+            NameQueryBuilder()
+            .with_instance(instance)
+            .with_name(name)
+            .ordered_by("?num")
+            .with_limit(10)
+            .build()
+        )
 
         res = return_sparql_query_results(query)
 
@@ -55,31 +53,33 @@ class HistreeQuery:
 
         for (i, row) in enumerate(res["results"]["bindings"]):
             qid_label_map[i] = {
-                "id": row["item"]["value"].split('/')[-1],
+                "id": row["item"]["value"].split("/")[-1],
                 "label": row["label"]["value"],
-                "description": row["description"]["value"]
+                "description": row["description"]["value"],
             }
 
         return qid_label_map
 
     @staticmethod
-    def get_tree_from_id(qid: str, seed: WikiSeed = FamilySeed.instance(), branch_up_levels: int = 2, branch_down_levels: int = 2) -> Dict[str, any]:
+    def get_tree_from_id(
+        qid: str,
+        seed: WikiSeed = FamilySeed.instance(),
+        branch_up_levels: int = 1,
+        branch_down_levels: int = 1,
+    ) -> Dict[str, any]:
         tree = WikiTree(seed)
-        tree.grow_levels(
-            qid, branch_up_levels, branch_down_levels)
+        tree.grow_levels(qid, branch_up_levels, branch_down_levels)
         return tree.to_json()
 
     def _query_cli() -> None:
         name = input("Name to Query: ")
-        matches = list(
-            HistreeQuery.search_matching_names(name).items())
+        matches = list(HistreeQuery.search_matching_names(name).items())
 
         print("Potential matches for Query: ")
         for (i, label) in enumerate(matches):
             print(f"{i + 1}. {label[1]}")
 
-        index = int(
-            input("Choose the option you wish to query: ")) - 1
+        index = int(input("Choose the option you wish to query: ")) - 1
         qid = matches[index][0]
 
         tree_json = HistreeQuery.get_tree_from_id(qid)


### PR DESCRIPTION
JIRA Link: [HIS-54](https://histree.atlassian.net/browse/HIS-54?atlOrigin=eyJpIjoiYzFhMmVjZDlkNjg0NDE0MmI2M2QwYWNiOGM5MDlhNjYiLCJwIjoiaiJ9)

# Description
## Additions
- Created a SPARQL query builder for finer-grained queries.
  - Useful for filtering query results more dynamically.
- Created a builder for searching names.
- Added tests for the query builder.

## Next Steps
I found SPARQL to be way faster than the Linked Data Interface (current implementation) to get information about people we're interested in. 

Currently, it takes roughly 500ms to query a single person's details plus a little more for parsing the information. For a family tree with over a hundred people, the time compounds rapidly. Using SPARQL, however, one can find properties of multiple people (e.g. a hundred) together in a **single** query, lasting only around 700ms. 

With the generalised query builder, we can easily decouple `WikiPetal` and `WikiTree` from `qwikidata`'s `WikidataItem` class, on top of having tree generation that is magnitudes faster.


