### PR TITLE
HIS-66-simple-relationship-api: create a simple API endpoint for quer…

### DIFF
--- a/histree_backend/histree.py
+++ b/histree_backend/histree.py
@@ -36,3 +36,19 @@ def person_info(qid):
         response = Response()
     response.headers.add("Access-Control-Allow-Origin", "*")
     return response
+
+
+# Pass in the Wiki IDs of two people and return a json of their relationship
+@app.route('/relationship', methods=['GET'])
+def relationship_calculator():
+    id1 = request.args.get('id1', default="", type=str)
+    id2 = request.args.get('id2', default="", type=str)
+    result = {"relationship" : "sibling"}
+
+    try:
+        response = jsonify(result)
+    except JSONDecodeError:
+        response = Response()
+
+    response.headers.add("Access-Control-Allow-Origin", "*")
+    return response

--- a/histree_backend/templates/intro.html
+++ b/histree_backend/templates/intro.html
@@ -6,5 +6,6 @@
         <h1>Visualising complex genealogy - API!</h1>
         <p>/find_matches/name</p>
         <p>/person_info/qid</p>
+        <p>/relationship?id1=id1&id2=id2</p>
     </body>
 </html>


### PR DESCRIPTION
HIS-66: creating a simple API endpoint for querying relationships

JIRA Link: [HIS-66](https://histree.atlassian.net/jira/software/projects/HIS/boards/1?selectedIssue=HIS-66)

This creates a simple API endpoint for relationship calculation.
The format of the request is `/relationship?id1=id1&id2=id2`. 

A JSON in the form `{"relationship":"sibling"}` is returned. 
This relationship means: 
> id1 is the _ of id2

As of now, the IDs are not used to compute the relationship and a default value is returned.
