### PR TITLE
HIS-74: add endpoint for multiple id queries

### DIFF
--- a/histree_backend/histree.py
+++ b/histree_backend/histree.py
@@ -5,17 +5,16 @@ from histree_query import HistreeQuery
 app = Flask(__name__)
 
 
-@app.route('/')
+@app.route("/")
 def greet():
-    return render_template('intro.html')
+    return render_template("intro.html")
 
 
 # Pass in a name and return a dictionary of potential matches names to Wiki IDs
-@app.route('/find_matches/<name>')
+@app.route("/find_matches/<name>")
 def find_matches(name: str):
     try:
-        response = jsonify(
-            HistreeQuery.search_matching_names(name))
+        response = jsonify(HistreeQuery.search_matching_names(name))
     except JSONDecodeError:
         response = Response()
     response.headers.add("Access-Control-Allow-Origin", "*")
@@ -23,15 +22,40 @@ def find_matches(name: str):
 
 
 # Pass in a Wiki ID and return a json of all their relevant data
-@app.route('/person_info/<qid>')
+@app.route("/person_info/<qid>")
 def person_info(qid):
-    depth_up = request.args.get(
-        'depth_up', default=1, type=int)
-    depth_down = request.args.get(
-        'depth_down', default=1, type=int)
+    depth_up = request.args.get("depth_up", default=1, type=int)
+    depth_down = request.args.get("depth_down", default=1, type=int)
     try:
-        response = jsonify(HistreeQuery.get_tree_from_id(
-            qid, branch_up_levels=depth_up, branch_down_levels=depth_down))
+        response = jsonify(
+            HistreeQuery.get_tree_from_ids(
+                [qid], branch_up_levels=depth_up, branch_down_levels=depth_down
+            )
+        )
+    except JSONDecodeError:
+        response = Response()
+    response.headers.add("Access-Control-Allow-Origin", "*")
+    return response
+
+
+# Pass in a list of Wiki IDs and return a json of all their relevant data
+@app.route("/persons_info", methods=["POST"])
+def persons_info():
+    body = request.json
+
+    depth_up = body.get("depth_up", 1)
+    depth_down = body.get("depth_down", 1)
+    ids = request.json.get("ids", [])
+
+    if not ids:
+        return Response()
+
+    try:
+        response = jsonify(
+            HistreeQuery.get_tree_from_ids(
+                ids, branch_up_levels=depth_up, branch_down_levels=depth_down
+            )
+        )
     except JSONDecodeError:
         response = Response()
     response.headers.add("Access-Control-Allow-Origin", "*")
@@ -39,11 +63,11 @@ def person_info(qid):
 
 
 # Pass in the Wiki IDs of two people and return a json of their relationship
-@app.route('/relationship', methods=['GET'])
+@app.route("/relationship", methods=["GET"])
 def relationship_calculator():
-    id1 = request.args.get('id1', default="", type=str)
-    id2 = request.args.get('id2', default="", type=str)
-    result = {"relationship" : "sibling"}
+    id1 = request.args.get("id1", default="", type=str)
+    id2 = request.args.get("id2", default="", type=str)
+    result = {"relationship": "sibling"}
 
     try:
         response = jsonify(result)

--- a/histree_backend/histree_query.py
+++ b/histree_backend/histree_query.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict
+from typing import Dict, List
 from data_retrieval.query.name_query import NameQueryBuilder
 from data_retrieval.wikitree.tree import WikiSeed, WikiTree
 from data_retrieval.wikitree_instance.familytree.seed import FamilySeed
@@ -62,14 +62,14 @@ class HistreeQuery:
         return qid_label_map
 
     @staticmethod
-    def get_tree_from_id(
-        qid: str,
+    def get_tree_from_ids(
+        qids: List[str],
         seed: WikiSeed = FamilySeed.instance(),
         branch_up_levels: int = 1,
         branch_down_levels: int = 1,
     ) -> Dict[str, any]:
         tree = WikiTree(seed)
-        tree.grow_levels([qid], branch_up_levels, branch_down_levels)
+        tree.grow_levels(qids, branch_up_levels, branch_down_levels)
         tree.write_to_database()
         return tree.to_json()
 
@@ -84,5 +84,5 @@ class HistreeQuery:
         index = int(input("Choose the option you wish to query: ")) - 1
         qid = matches[index][0]
 
-        tree_json = HistreeQuery.get_tree_from_id(qid)
+        tree_json = HistreeQuery.get_tree_from_ids([qid])
         print(tree_json)


### PR DESCRIPTION
JIRA Link: [HIS-74](https://histree.atlassian.net/browse/HIS-74?atlOrigin=eyJpIjoiODQxNjJlYzU3YzgyNDk2NWE1NmMzYzg4MDEyZWM4YzkiLCJwIjoiaiJ9)

# Description

Added endpoint for querying multiple people at once. An example is:
```
endpoint:
http://127.0.0.1:5000/persons_info/

request body:
{
  "ids": ["Q9682", "Q937"],
  "depth_up": 2,
  "depth_down": 2
}
```
Note the difference with `/person_info` which only takes one id.
