### PR TITLE
His 77 location petals

### DIFF
--- a/histree_backend/data_retrieval/query/builder.py
+++ b/histree_backend/data_retrieval/query/builder.py
@@ -28,7 +28,11 @@ class SPARQLBuilder:
         )
         header_bindings = " ".join(
             ("OPTIONAL{%s}" if config["optional"] else "%s")
-            % f"?item wdt:{config['id']} ?{header}."
+            % (
+                f"?{header}_item ^wdt:{config['id']} item; rdfs:label ?{header}."
+                if config["label_only"]
+                else f"?item wdt:{config['id']} ?{header}."
+            )
             for (header, config) in self.headers.items()
             if config["id"] != self._hidden_header_id
         )

--- a/histree_backend/data_retrieval/wikitree/flower.py
+++ b/histree_backend/data_retrieval/wikitree/flower.py
@@ -25,6 +25,12 @@ class WikiFlower:
         if for_db:
             json_dict["branched_up"] = self.branched_up
             json_dict["branched_down"] = self.branched_down
+
+            # Only return id for nested properties as db can only handle primitives
+            for k, v in json_dict["petals"].items():
+                if isinstance(v, dict):
+                    json_dict["petals"][k] = v["id"]
+
         if self.description:
             json_dict["description"] = self.description
         return json_dict

--- a/histree_backend/data_retrieval/wikitree/flower.py
+++ b/histree_backend/data_retrieval/wikitree/flower.py
@@ -1,7 +1,5 @@
 from abc import abstractmethod
 from typing import Dict, List, Tuple
-from qwikidata.entity import WikidataItem
-from .tree import WikiSeed
 
 
 class WikiFlower:
@@ -56,9 +54,9 @@ class WikiPetal:
         optional: bool = True,
         sample: bool = False,
         label_only: bool = False,
-        lazy_seed: WikiSeed = None,
+        lazy_seed: "WikiSeed" = None,
     ):
-        """ 
+        """
         id:             wikidata property id
         label:          property label
         optional:       specifies if entries MUST have this attribute

--- a/histree_backend/data_retrieval/wikitree/flower.py
+++ b/histree_backend/data_retrieval/wikitree/flower.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 from typing import Dict, List, Tuple
 from qwikidata.entity import WikidataItem
+from .tree import WikiSeed
 
 
 class WikiFlower:
@@ -49,18 +50,36 @@ class WikiPetal:
     undefined = "undefined"
 
     def __init__(
-        self, id: str, label: str, optional: bool = True, sample: bool = False
+        self,
+        id: str,
+        label: str,
+        optional: bool = True,
+        sample: bool = False,
+        label_only: bool = False,
+        lazy_seed: WikiSeed = None,
     ):
+        """ 
+        id:             wikidata property id
+        label:          property label
+        optional:       specifies if entries MUST have this attribute
+        sample:         specifies if only a sample of possibly many should be taken
+        lazy_seed:      specifies the seed of how the attribute is to be queried further
+        label_only:     specifies if attribute is given by an id but only label is required
+        """
         self.id = id
         self.label = label
         self.optional = optional
         self.sample = sample
+        self.lazy_seed = lazy_seed
+        self.label_only = label_only
 
     def to_dict_pair(self) -> Tuple[str, Dict[str, any]]:
         return self.label, {
             "id": self.id,
             "optional": self.optional,
             "sample": self.sample,
+            "lazy_seed": self.lazy_seed,
+            "label_only": self.label_only,
         }
 
     @abstractmethod

--- a/histree_backend/data_retrieval/wikitree/tree.py
+++ b/histree_backend/data_retrieval/wikitree/tree.py
@@ -200,6 +200,7 @@ class WikiTree:
                     flower
                     for flower in self.flowers.values()
                     if lazy_petal.label in flower.petals
+                    and not isinstance(flower.petals[lazy_petal.label], dict)
                 ]
                 lazy_ids = [flower.petals[lazy_petal.label] for flower in rel_flowers]
                 lazy_result = self.api.query(

--- a/histree_backend/data_retrieval/wikitree/tree.py
+++ b/histree_backend/data_retrieval/wikitree/tree.py
@@ -202,6 +202,8 @@ class WikiTree:
                     if lazy_petal.label in flower.petals
                     and not isinstance(flower.petals[lazy_petal.label], dict)
                 ]
+                if not rel_flowers:
+                    continue
                 lazy_ids = [flower.petals[lazy_petal.label] for flower in rel_flowers]
                 lazy_result = self.api.query(
                     lazy_petal.lazy_seed.self_stem.get_query(lazy_ids)

--- a/histree_backend/data_retrieval/wikitree_instance/familytree/petals.py
+++ b/histree_backend/data_retrieval/wikitree_instance/familytree/petals.py
@@ -1,33 +1,11 @@
 from data_retrieval.wikitree.flower import WikiPetal
 from data_retrieval.wikitree_instance.familytree.property import PROPERTY_MAP
+from data_retrieval.wikitree_instance.locationtree.seed import LocationSeed
 
-
-class GenderPetal(WikiPetal):
-    gender_map = {
-        "Q6581097": "male",
-        "Q6581072": "female",
-        "Q48270": "non-binary",
-        "Q1097630": "intersex",
-        "Q2449503": "transgender male",
-        "Q1052281": "transgender female",
-        "Q505371": "agender",
-    }
-    genders = set(gender_map.values())
-
-    def __init__(self):
-        label = "gender"
-        super().__init__(PROPERTY_MAP["petals"][label], label, True, False)
-
-    def parse(self, value: str) -> str:
-        if value in self.genders:
-            return value
-        id = value.split("/")[-1]
-        return self.gender_map.get(id, self.undefined)
-
-
+# Date Attributes
 class DatePetal(WikiPetal):
     def __init__(self, id, label):
-        super().__init__(id, label, True, False)
+        super().__init__(id, label, optional=True)
 
     def parse(self, value: str) -> str:
         if not value:
@@ -47,27 +25,90 @@ class DeathDatePetal(DatePetal):
         super().__init__(PROPERTY_MAP["petals"][label], label)
 
 
+# Location Attributes
+class LocationPetal(WikiPetal):
+    def __init__(self, id, label):
+        super().__init__(id, label, optional=True, lazy_seed=LocationSeed.instance())
+
+    def parse(self, value: str) -> str:
+        if not value:
+            return self.undefined
+        return value.split("/")[-1]
+
+
+class BirthPlacePetal(LocationPetal):
+    def __init__(self):
+        label = "place_of_birth"
+        super().__init__(PROPERTY_MAP["petals"][label], label)
+
+
+class DeathPlacePetal(LocationPetal):
+    def __init__(self):
+        label = "place_of_death"
+        super().__init__(PROPERTY_MAP["petals"][label], label)
+
+
+# Personal Attributes
+class GenderPetal(WikiPetal):
+    gender_map = {
+        "Q6581097": "male",
+        "Q6581072": "female",
+        "Q48270": "non-binary",
+        "Q1097630": "intersex",
+        "Q2449503": "transgender male",
+        "Q1052281": "transgender female",
+        "Q505371": "agender",
+    }
+    genders = set(gender_map.values())
+
+    def __init__(self):
+        label = "gender"
+        super().__init__(
+            PROPERTY_MAP["petals"][label], label, optional=True, sample=True
+        )
+
+    def parse(self, value: str) -> str:
+        if value in self.genders:
+            return value
+        id = value.split("/")[-1]
+        return self.gender_map.get(id, self.undefined)
+
+
 class BirthNamePetal(WikiPetal):
     def __init__(self):
         label = "birth_name"
-        super().__init__(PROPERTY_MAP["petals"][label], label, True, True)
+        super().__init__(
+            PROPERTY_MAP["petals"][label], label, optional=True, sample=True
+        )
 
     def parse(self, value: str) -> str:
         return value
 
 
+# Miscellaneous Attributes
 class ImagePetal(WikiPetal):
     def __init__(self):
         label = "image"
-        super().__init__(PROPERTY_MAP["petals"][label], label, True, True)
+        super().__init__(
+            PROPERTY_MAP["petals"][label], label, optional=True, sample=True
+        )
 
     def parse(self, value: str) -> str:
         return value
 
 
+class CallerPetal(WikiPetal):
+    def __init__(self):
+        super().__init__(-1, "caller")
+
+    def parse(self, value: str) -> str:
+        return value.split("/")[-1]
+
+
+# Relationship Attributes
 class RelationPetal(WikiPetal):
     def __init__(self, id, label):
-        super().__init__(id, label, True, True)
+        super().__init__(id, label, optional=True, sample=True)
 
     def parse(self, value: str) -> str:
         return value.split("/")[-1]
@@ -83,11 +124,3 @@ class MotherPetal(RelationPetal):
     def __init__(self):
         label = "mother"
         super().__init__(PROPERTY_MAP["stems"][label], label)
-
-
-class CallerPetal(WikiPetal):
-    def __init__(self):
-        super().__init__(-1, "caller", False, False)
-
-    def parse(self, value: str) -> str:
-        return value.split("/")[-1]

--- a/histree_backend/data_retrieval/wikitree_instance/familytree/property.py
+++ b/histree_backend/data_retrieval/wikitree_instance/familytree/property.py
@@ -4,7 +4,9 @@ PROPERTY_MAP = {
         "date_of_birth": "P569",
         "date_of_death": "P570",
         "image": "P18",
-        "gender": "P21"
+        "gender": "P21",
+        "place_of_birth": "P19",
+        "place_of_death": "P20",
     },
     "stems": {
         "child": "P40",

--- a/histree_backend/data_retrieval/wikitree_instance/familytree/seed.py
+++ b/histree_backend/data_retrieval/wikitree_instance/familytree/seed.py
@@ -12,10 +12,12 @@ class FamilySeed(WikiSeed):
             up_stem=ParentStem.instance(),
             down_stem=ChildStem.instance(),
             petals=[
+                BirthNamePetal.instance(),
                 GenderPetal.instance(),
                 BirthDatePetal.instance(),
+                BirthPlacePetal.instance(),
                 DeathDatePetal.instance(),
-                BirthNamePetal.instance(),
+                DeathPlacePetal.instance(),
                 ImagePetal.instance(),
             ],
         )

--- a/histree_backend/data_retrieval/wikitree_instance/familytree/stems.py
+++ b/histree_backend/data_retrieval/wikitree_instance/familytree/stems.py
@@ -2,7 +2,7 @@ from typing import Dict, List
 from data_retrieval.query.builder import SPARQLBuilder
 from data_retrieval.wikitree.flower import WikiStem, UpWikiStem, DownWikiStem
 from data_retrieval.wikitree_instance.familytree.property import PROPERTY_MAP
-from .petals import FatherPetal, MotherPetal, CallerPetal
+from data_retrieval.wikitree_instance.familytree.petals import FatherPetal, MotherPetal, CallerPetal
 
 
 class SelfStem(WikiStem):

--- a/histree_backend/data_retrieval/wikitree_instance/locationtree/petals.py
+++ b/histree_backend/data_retrieval/wikitree_instance/locationtree/petals.py
@@ -1,0 +1,47 @@
+from data_retrieval.wikitree.flower import WikiPetal
+from data_retrieval.wikitree_instance.locationtree.property import PROPERTY_MAP
+
+# Location Attributes
+class CoordinatesPetal(WikiPetal):
+    def __init__(self):
+        label = "coordinate_location"
+        super().__init__(PROPERTY_MAP["petals"][label], label, optional=True)
+
+    def parse(self, value: str) -> str:
+        longitude, latitude = value.removeprefix("Point(").removesuffix(")").split(" ")
+        return {"latitude": latitude, "longitude": longitude}
+
+
+# Miscellaneous Attributes
+class ImagePetal(WikiPetal):
+    def __init__(self):
+        label = "image"
+        super().__init__(
+            PROPERTY_MAP["petals"][label], label, optional=True, sample=True
+        )
+
+    def parse(self, value: str) -> str:
+        return value
+
+
+class CallerPetal(WikiPetal):
+    def __init__(self):
+        super().__init__(-1, "caller")
+
+    def parse(self, value: str) -> str:
+        return value.split("/")[-1]
+
+
+# Relationship Attributes
+class RelationPetal(WikiPetal):
+    def __init__(self, id, label):
+        super().__init__(id, label, optional=True, sample=True)
+
+    def parse(self, value: str) -> str:
+        return value.split("/")[-1]
+
+
+class LocationPetal(RelationPetal):
+    def __init__(self):
+        label = "location"
+        super().__init__(PROPERTY_MAP["stems"][label], label)

--- a/histree_backend/data_retrieval/wikitree_instance/locationtree/property.py
+++ b/histree_backend/data_retrieval/wikitree_instance/locationtree/property.py
@@ -1,0 +1,11 @@
+PROPERTY_MAP = {
+    "petals": {
+        "country": "P17",
+        "image": "P18",
+        "territorial_location": "P131",
+        "coordinate_location": "P625",
+    },
+    "stems": {
+        "location": "P276",
+    },
+}

--- a/histree_backend/data_retrieval/wikitree_instance/locationtree/seed.py
+++ b/histree_backend/data_retrieval/wikitree_instance/locationtree/seed.py
@@ -1,0 +1,37 @@
+from data_retrieval.wikitree.tree import WikiSeed, WikiTree
+from data_retrieval.wikitree_instance.locationtree.petals import *
+from data_retrieval.wikitree_instance.locationtree.stems import *
+
+
+class LocationSeed(WikiSeed):
+    _instance = None
+
+    def __init__(self):
+        super().__init__(
+            self_stem=SelfStem.instance(),
+            up_stem=None,
+            down_stem=None,
+            petals=[
+                CallerPetal.instance(),
+                CoordinatesPetal.instance(),
+                ImagePetal.instance(),
+            ],
+        )
+
+    @classmethod
+    def instance(cls):
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+
+class LocationTree(WikiTree):
+    _instance = None
+
+    def __init__(self):
+        super.__init__(LocationSeed.instance())
+
+    def instance(cls):
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance

--- a/histree_backend/data_retrieval/wikitree_instance/locationtree/stems.py
+++ b/histree_backend/data_retrieval/wikitree_instance/locationtree/stems.py
@@ -1,0 +1,18 @@
+from typing import Dict
+from data_retrieval.query.builder import SPARQLBuilder
+from data_retrieval.wikitree.flower import WikiStem
+
+
+class SelfStem(WikiStem):
+    def __init__(self):
+        super().__init__(-1)
+
+    def set_query_template(self, headers: Dict[str, any]) -> None:
+        value_label = "?place"
+        self.template = (
+            SPARQLBuilder(headers)
+            .bounded_to("?caller", value_label)
+            .with_values(value_label, [self._TEMPLATE_STR], prefix=False)
+            .bounded_to("?item", value_label)
+            .build()
+        )

--- a/histree_backend/histree_query.py
+++ b/histree_backend/histree_query.py
@@ -69,7 +69,7 @@ class HistreeQuery:
         branch_down_levels: int = 1,
     ) -> Dict[str, any]:
         tree = WikiTree(seed)
-        tree.grow_levels(qids, branch_up_levels, branch_down_levels)
+        tree.grow_levels(qids, branch_up_levels, branch_down_levels, is_entry_point=True)
         tree.write_to_database()
         return tree.to_json()
 


### PR DESCRIPTION
JIRA Link: [HIS-77](https://histree.atlassian.net/browse/HIS-77?atlOrigin=eyJpIjoiN2FlMmQzYzMwMTE1NDJiOWJjNmNhZjZiMzFmZjVhZGUiLCJwIjoiaiJ9)

# Description
## Additions
- Created a `LocationSeed` for determining the petals (attributes) to be retrieved when querying locations.
- Added petals for birth and death places.
- Enabled petals returning entities to be retrieved label-only.

## How it Works
When attributes of an entity are queried from Wikidata, those which correspond to existing entities are returned as an id (e.g. birthplace might return `Q124184`). Thus we need to make further queries to expound on these ids. However, they could refer to animals, locations or even abstract concepts of which only specific properties exist. To address this, we can create a `WikiSeed` for each one to determine which attributes to query. For example, `LocationSeed` was specifically designed to address location queries in `FamilyTree`. It contains petals for its image and coordinates.

An alternative way to do this is by returning only the label of the ids (e.g. instead of `Q124184`, we only get `"Mayfair"`). Support for this is now available in the query builder, should we need it.

## Current Issues
The database has to be cleared whenever new petals are added, as some entries could have populated the database before the new petals were ever queried. Also, as we don't query WikiData when an entry is in the database, the result could be a group of flowers missing specific properties.

Currently, there are no mechanisms to save nested dictionaries as properties in the database. Below is an example JSON representation of a flower:
```
{
    "description": "Classical Greek philosopher and polymath (384–322 BC)",
    "id": "Q868",
    "name": "Aristotle",
    "petals": {
      "date_of_birth": "-0383-01-01",
      "date_of_death": "-0321-01-01",
      "gender": "male",
      "image": "http://commons.wikimedia.org/wiki/Special:FilePath/Aristotle%20Altemps%20Inv8575.jpg",
      "place_of_birth": {
        "description": "ancient city in Macedonia, Greece",
        "id": "Q846127",
        "name": "Stagira",
        "petals": {
          "coordinate_location": {
            "latitude": "40.59083333",
            "longitude": "23.79416667"
          },
          "image": "http://commons.wikimedia.org/wiki/Special:FilePath/Ancient%20stagira%20greece%2001.jpg"
        }
      }
    }
}
```
Here, `place_of_birth` is a nested flower for a location with id `Q846127`. The database requires a primitive type for each property and thus cannot make use of this. A way around this could be to also store these location flowers as nodes in the database and set the property to refer to its id (e.g. `"place_of_birth": "Q846127"`). When a person is queried, the database simply looks for the node responsible for this location.

As a temporary workaround, I have made it so only the ids are stored in the database, and locations are to be always queried.