### PR TITLE
HIS-87: refac code and make petal names bold

### DIFF
--- a/histree-frontend/src/components/Flow.tsx
+++ b/histree-frontend/src/components/Flow.tsx
@@ -75,12 +75,13 @@ const Flow = (props: { content: RenderContent }) => {
 		const positions: NodePositions = {};
 		Object.keys(nodes).forEach((node) => {
 			// if (nodes[node].visible) {
-			const { id, name, petals, description } = nodes[node];
+			const { id, name, petals, description, article } = nodes[node];
 			graph.setNode(id, {
 				label: name,
 				qid: id,
 				petals: petals,
 				description: description,
+				article: article,
 				width: NODE_BOX_WIDTH,
 				height: NODE_BOX_HEIGHT
 			});
@@ -113,7 +114,8 @@ const Flow = (props: { content: RenderContent }) => {
 						name: nodeObj.label,
 						description: nodeObj.description,
 						id: n,
-						petals: nodeObj.petals
+						petals: nodeObj.petals,
+						article: nodeObj.article
 					},
 					// hidden: !nodeLookup[n].visible,
 					position: { x: nodeObj.x, y: nodeObj.y },

--- a/histree-frontend/src/components/TreeNode.tsx
+++ b/histree-frontend/src/components/TreeNode.tsx
@@ -47,6 +47,7 @@ const TreeNode = ({ data }: { data: NodeInfo }) => {
 		if (renderMode === 'View') {
 			dispatch(
 				setSelected({
+					article: data.article,
 					name: data.name,
 					image: data?.image,
 					attributes: data.petals,

--- a/histree-frontend/src/components/general/DescriptorCard.tsx
+++ b/histree-frontend/src/components/general/DescriptorCard.tsx
@@ -85,44 +85,30 @@ export const DescriptorCard = forwardRef<HTMLDivElement, DescriptorCardProps>(
                   .map((att) => {
                     const attrName = att.charAt(0).toUpperCase() + att.slice(1);
                     const attrVal = selectedItem.attributes![att];
-                    // make this nicer code
                     var attrDesc = ''
                   
                     if (attrVal === 'undefined') {
                       attrDesc = 'Unknown'
-                    } else if (typeof attrVal === 'string') {
-                      attrDesc = attrVal.charAt(0).toUpperCase() + attrVal.slice(1);
-                    } else {
-                      // case for locations with their own sub-jsons
+                    } else if (typeof attrVal === 'object') {
+                      // For locations: when att = 'place_of_birth' or 'place_of_death'
+                      // and contains sub-JSONs
                       attrDesc = attrVal['name'];
+                    } else {
+                      attrDesc = attrVal.charAt(0).toUpperCase() + attrVal.slice(1);
                     }
-                    
+
                     return (
                       <Typography key={att} variant="body2">
-                        {`${attrName.replace(/_/g, ' ')}: ${attrDesc}`}
+                        <b>{attrName.replace(/_/g, ' ')}:</b> {attrDesc}
                       </Typography>
                     );
                   })}
-              <br />
-              
             </Box>
           </CardContent>
           <CardActions>
-            <>
-              {selectedItem.links &&
-                Object.keys(selectedItem.links).map((linkName) => {
-                  return (
-                    <Button
-                      key={linkName}
-                      size="small"
-                      href={selectedItem.links![linkName]}
-                    >
-                      {linkName}
-                    </Button>
-                  );
-                })}
-            </>
+            <Button href={selectedItem.article} target="_blank">Learn More</Button>
           </CardActions>
+          
         </Card>
       </div>
     );

--- a/histree-frontend/src/models/graphInfo.ts
+++ b/histree-frontend/src/models/graphInfo.ts
@@ -3,6 +3,7 @@ export type NodeId = string;
 export type HandleStatus = "None" | "Loading" | "Complete" | "NoData";
 
 export type NodeInfo = {
+  article: string;
   name: string;
   id: NodeId;
   description?: string;

--- a/histree-frontend/src/models/selected.ts
+++ b/histree-frontend/src/models/selected.ts
@@ -1,9 +1,9 @@
 export type Url = string;
 
 export interface Selected {
+  article: Url;
   name: string;
   image?: Url;
   attributes?: Record<string, string>;
   description?: string;
-  links?: Record<string, Url>;
 }


### PR DESCRIPTION
JIRA Link: [HIS-87](https://histree.atlassian.net/browse/HIS-87?atlOrigin=eyJpIjoiM2UxODFhN2JlMjYxNDc4OWI2ZjEyMjE2ZDE2YjAyYmYiLCJwIjoiaiJ9)

Adds a 'LEARN MORE' button at the bottom of each descriptor card to allow users to navigate to the relevant Wiki Article for each node. Also makes the attribute field names in the card bold.
