### PR TITLE
HIS-102: add header name and descriptor card back

### DIFF
--- a/histree-frontend/src/components/general/DescriptorCard.tsx
+++ b/histree-frontend/src/components/general/DescriptorCard.tsx
@@ -99,7 +99,26 @@ export const DescriptorCard = forwardRef<HTMLDivElement, DescriptorCardProps>(
 									alt={selectedItem.attributes!['image']}
 								/>
 							)}
-
+						<CardHeader
+							onClick={closeWindow}
+							action={
+								<IconButton aria-label="close">
+									<CloseIcon></CloseIcon>
+								</IconButton>
+							}
+							title={selectedItem.name}
+							subheader={selectedItem.description &&
+								selectedItem.description !== 'undefined' ? (
+								<Typography variant="body2" color="text.secondary">
+									{selectedItem.description.charAt(0).toUpperCase() +
+										selectedItem.description.slice(1)}
+								</Typography>
+							) : (
+								<Typography variant="body2" color="text.secondary">
+									Description not available.
+								</Typography>
+							)}
+						/>
 						<CardContent>
 							<Box className="descriptor-container-body">
 


### PR DESCRIPTION
JIRA Link: [HIS-102](https://histree.atlassian.net/browse/HIS-102?atlOrigin=eyJpIjoiZDM3ZWY0ODdlYzY4NGM5MWI5MDM0NTgyNDk3OTdiMjAiLCJwIjoiaiJ9)

# Description

Add descriptor title back
