### PR TITLE
His 90 better entity search

### DIFF
--- a/histree_backend/data_retrieval/query/name_query.py
+++ b/histree_backend/data_retrieval/query/name_query.py
@@ -4,17 +4,28 @@ from .builder import SPARQLBuilder
 
 class NameQueryBuilder(SPARQLBuilder):
     def __init__(
-        self, language: str = "en", headers: Dict[str, Dict[str, any]] = dict()
+        self,
+        pagination: int = 0,
+        search_limit: int = 50,
+        language: str = "en",
+        headers: Dict[str, Dict[str, any]] = dict(),
     ):
         super().__init__(language=language, headers=headers)
+
+        # Note: this limit corresponds to MediaWiki search results
+        # By their conventions, results are capped at 50.
+        self.search_limit = search_limit
+        self.pagination = pagination
 
     def with_name(self, name: str) -> "NameQueryBuilder":
         self.other = f"""
                 SERVICE wikibase:mwapi {{
-                    bd:serviceParam wikibase:api "EntitySearch" .
-                    bd:serviceParam wikibase:endpoint "www.wikidata.org" .
-                    bd:serviceParam mwapi:search "{name}" .
-                    bd:serviceParam mwapi:language "{self.language}" .
+                    bd:serviceParam wikibase:api "EntitySearch";
+                                    wikibase:endpoint "www.wikidata.org";
+                                    mwapi:search "{name}";
+                                    mwapi:language "{self.language}";
+                                    mwapi:limit {self.search_limit} ;
+                                    mwapi:continue {self.search_limit * self.pagination} .
                     ?item wikibase:apiOutputItem mwapi:item .
                     ?num wikibase:apiOrdinal true .
                 }}

--- a/histree_backend/histree_query.py
+++ b/histree_backend/histree_query.py
@@ -36,7 +36,7 @@ class HistreeQuery:
     def search_matching_names(
         name: str,
         instance: str = "Q5",
-        pages: int = 3,
+        pages: int = 2,
         language: str = "en",
     ) -> Dict[int, Dict[str, str]]:
         # Check if name has been queried before in db and return if so


### PR DESCRIPTION
JIRA Link: [HIS-90](https://histree.atlassian.net/browse/HIS-90?atlOrigin=eyJpIjoiOTRiYjUyMTRhNzY0NDFjMjhmYWQ1NGJjYzM5NmUwYzMiLCJwIjoiaiJ9)

# Description
## Additions
- Returned more than one paginated result from MediaWiki EntitySearch API when using the `find_matches` endpoint.
  - This should address the issue where only one result comes up for the search term: "Victoria".
  - This spawns threads (two by default) to make concurrent SPARQL requests for different pages.
    - This can't be done in a single request as results are capped at 50 per request.
    - This can be done in two separate requests but will double the waiting time.
  -  However, there is [a limit of five concurrent requests](https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual#Query_limits) per IP address, so intense use of the search bar may be an issue.
     - A possible way around this is to make the search queries from the client side.
- Adapted name query builder to accept pagination parameters.
