### PR TITLE
His 98 shortest path ids

### DIFF
--- a/histree_backend/database/cypher_runner.py
+++ b/histree_backend/database/cypher_runner.py
@@ -122,8 +122,6 @@ def shortest_path_properties(tx, person_id1, person_id2):
     return query, label
 
 
-
-
 @cypher_runner
 def shortest_distance(tx, person_id1, person_id2):
     query = (

--- a/histree_backend/database/cypher_runner.py
+++ b/histree_backend/database/cypher_runner.py
@@ -112,7 +112,7 @@ def shortest_path_properties(tx, person_id1, person_id2):
     query = (
         "MATCH (p1:Person {id: \'" + person_id1 + "\'}), "
         "(p2:Person {id: \'" + person_id2 + "\'}), "
-        "path = shortestPath((p1)-[PARENT_OF*]-(p2)) "
+        "path = shortestPath((p1)<-[PARENT_OF*]-(p2)) "
         "WITH reduce(output = [], n in nodes(path) | output + n) as nodeCollection "
         "UNWIND nodeCollection as route "
         "RETURN properties(route) AS properties"

--- a/histree_backend/database/cypher_runner.py
+++ b/histree_backend/database/cypher_runner.py
@@ -108,6 +108,23 @@ def common_ancestor(tx, person_id1, person_id2):
 
 
 @cypher_runner
+def shortest_path_properties(tx, person_id1, person_id2):
+    query = (
+        "MATCH (p1:Person {id: \'" + person_id1 + "\'}), "
+        "(p2:Person {id: \'" + person_id2 + "\'}), "
+        "path = shortestPath((p1)-[PARENT_OF*]-(p2)) "
+        "WITH reduce(output = [], n in nodes(path) | output + n) as nodeCollection "
+        "UNWIND nodeCollection as route "
+        "RETURN properties(route) AS properties"
+    )
+
+    label = ["properties"]
+    return query, label
+
+
+
+
+@cypher_runner
 def shortest_distance(tx, person_id1, person_id2):
     query = (
         "MATCH (p1:Person {id: \'" + person_id1 + "\'}), "

--- a/histree_backend/database/neo4j_test.py
+++ b/histree_backend/database/neo4j_test.py
@@ -12,7 +12,6 @@ def db_connection():
     db.close()
 
 
-
 def test_find_common_ancestor(db_connection):
     # Common ancestor of Charles and Anne is Philip or Elizabeth 
     common_ancestor_id = db_connection.read_db(common_ancestor, "Q43274", "Q151754")[0][0]
@@ -47,12 +46,17 @@ def test_relationship_calculator(db_connection):
     relationship = RelationshipCalculator.calculate_relationship(db_connection, "Q10633", "Q43274")
     assert relationship == "grandmother"
 
-    # Lilibet Mountbatten-Windsor is the cousin of George of Wales 
-    relationship = RelationshipCalculator.calculate_relationship(db_connection, "Q107125551", "Q13590412")
-    assert relationship == "first cousin"
-
     # Anne is the aunt of Beatrice
     relationship = RelationshipCalculator.calculate_relationship(db_connection, "Q151754", "Q165657")
     assert relationship == "aunt"
+
+
+def test_shortest_path_ids(db_connection):
+    path = RelationshipCalculator.path_through_common_ancestor(db_connection, "Q154920", "Q80976", "Q80976")
+    assert path == ["Q154920", "Q80976"]
+
+    # Princess Beatrice to Lady Louise Windsor through Elizabeth
+    path = RelationshipCalculator.path_through_common_ancestor(db_connection, "Q165657", "Q680304", "Q9682")
+    assert path == ["Q165657", "Q153330", "Q9682", "Q154920", "Q680304"]
 
 

--- a/histree_backend/database/queries.txt
+++ b/histree_backend/database/queries.txt
@@ -16,7 +16,7 @@ RETURN a.id AS id
 ORDER BY length(path)
 LIMIT 1
 
-Philip: id: Q80976    is father of    Edward id: Q80976
+Philip: id: Q80976    is father of    Edward id: Q154920
 MATCH (p1:Person {id: 'Q43274'}), 
 (p2:Person {id: 'Q43274'}), 
 path = shortestPath((p1)-[*]-(p2)) 
@@ -25,10 +25,10 @@ RETURN length(path) AS length
 
 Path from Edward to Philip just contains those 2
 
-MATCH (p1:Person {id: 'Q80976'}),
+MATCH (p1:Person {id: 'Q154920'}),
 (p2:Person {id: 'Q80976'}),
-path = shortestPath((p1)-[PARENT_OF*]-(p2))
+path = shortestPath((p1)<-[PARENT_OF*]-(p2))
 WITH reduce(output = [], n in nodes(path) | output + n) as nodeCollection
 UNWIND nodeCollection as route
-RETURN properties(route)
+RETURN properties(route) AS properties
 

--- a/histree_backend/database/queries.txt
+++ b/histree_backend/database/queries.txt
@@ -16,8 +16,19 @@ RETURN a.id AS id
 ORDER BY length(path)
 LIMIT 1
 
-Philip: id: Q80976    is father of    Edward id: Q154920
+Philip: id: Q80976    is father of    Edward id: Q80976
 MATCH (p1:Person {id: 'Q43274'}), 
-(p2:Person {id: 'Q151754'}), 
+(p2:Person {id: 'Q43274'}), 
 path = shortestPath((p1)-[*]-(p2)) 
 RETURN length(path) AS length
+
+
+Path from Edward to Philip just contains those 2
+
+MATCH (p1:Person {id: 'Q80976'}),
+(p2:Person {id: 'Q80976'}),
+path = shortestPath((p1)-[PARENT_OF*]-(p2))
+WITH reduce(output = [], n in nodes(path) | output + n) as nodeCollection
+UNWIND nodeCollection as route
+RETURN properties(route)
+

--- a/histree_backend/database/relationship_calculator.py
+++ b/histree_backend/database/relationship_calculator.py
@@ -1,4 +1,4 @@
-from .cypher_runner import common_ancestor, shortest_distance, gender
+from .cypher_runner import common_ancestor, shortest_distance, gender, shortest_path_properties
 
 class RelationshipCalculator:
 
@@ -24,10 +24,35 @@ class RelationshipCalculator:
             RelationshipCalculator.cached_table = RelationshipCalculator.relationship_table()
 
         try:
-            return RelationshipCalculator.cached_table[distance1][distance2].get(gender1, RelationshipCalculator.cached_table[distance1][distance2]["default"])
+            relationship = RelationshipCalculator.cached_table[distance1][distance2].get(gender1, RelationshipCalculator.cached_table[distance1][distance2]["default"])
+            return relationship
         except (IndexError, KeyError) as error:
             print(error)
             return "has no close relationship with"
+
+
+    @staticmethod
+    def path_through_common_ancestor(db, id1, id2, ca_id):
+        '''Returns the single shortest path from id1 to id2 through ca_id'''
+        path1 = [id1]
+        if ca_id != id1:
+            properties = db.read_db(shortest_path_properties, id1, ca_id)
+            # list of tuples of dictionaries
+            path1 = [item[0]["id"] for item in properties]
+
+
+        print(f"Path 1: {path1}")
+
+        path2 = [id2]
+        if ca_id != id2:
+            properties = db.read_db(shortest_path_properties, id2, ca_id)[0]
+            # list of tuples of dictionaries
+            path2 = [item[0]["id"] for item in properties]
+
+        print(f"Path 2: {path2}")
+
+        path2.reverse()
+        return path1[:-1] + path2
 
 
     @staticmethod

--- a/histree_backend/database/relationship_calculator.py
+++ b/histree_backend/database/relationship_calculator.py
@@ -45,7 +45,7 @@ class RelationshipCalculator:
 
         path2 = [id2]
         if ca_id != id2:
-            properties = db.read_db(shortest_path_properties, id2, ca_id)[0]
+            properties = db.read_db(shortest_path_properties, id2, ca_id)
             # list of tuples of dictionaries
             path2 = [item[0]["id"] for item in properties]
 

--- a/histree_backend/database/relationship_calculator.py
+++ b/histree_backend/database/relationship_calculator.py
@@ -6,6 +6,11 @@ class RelationshipCalculator:
 
     @staticmethod
     def calculate_relationship(db, id1, id2):
+        '''Takes in the IDs of 2 people
+            Returns the following:
+            - relationship between the 2 (i.e. Person 1 is the _ of Person 2
+            - ID of one of their least common ancestors
+            - the IDs in the shortest path between them'''
         common_ancestors = db.read_db(common_ancestor, id1, id2)
         if not common_ancestors: # there is no common ancestor
             return "has no close relationship with" 
@@ -20,16 +25,18 @@ class RelationshipCalculator:
             distance2 = db.read_db(shortest_distance, id2, common_ancestor_id)[0][0]
         gender1 = db.read_db(gender, id1)[0][0]
 
+        path = RelationshipCalculator.path_through_common_ancestor(db, id1, id2, common_ancestor_id)
+
         if not RelationshipCalculator.cached_table:
             RelationshipCalculator.cached_table = RelationshipCalculator.relationship_table()
 
         try:
             relationship = RelationshipCalculator.cached_table[distance1][distance2].get(gender1, RelationshipCalculator.cached_table[distance1][distance2]["default"])
-            return relationship
+            return relationship, common_ancestor_id, path
         except (IndexError, KeyError) as error:
             print(error)
-            return "has no close relationship with"
-
+            return "has no close relationship with", "no ancestor", []
+            
 
     @staticmethod
     def path_through_common_ancestor(db, id1, id2, ca_id):

--- a/histree_backend/database/relationship_calculator.py
+++ b/histree_backend/database/relationship_calculator.py
@@ -47,16 +47,11 @@ class RelationshipCalculator:
             # list of tuples of dictionaries
             path1 = [item[0]["id"] for item in properties]
 
-
-        print(f"Path 1: {path1}")
-
         path2 = [id2]
         if ca_id != id2:
             properties = db.read_db(shortest_path_properties, id2, ca_id)
             # list of tuples of dictionaries
             path2 = [item[0]["id"] for item in properties]
-
-        print(f"Path 2: {path2}")
 
         path2.reverse()
         return path1[:-1] + path2

--- a/histree_backend/histree.py
+++ b/histree_backend/histree.py
@@ -65,17 +65,17 @@ def persons_info():
     return response
 
 
-# Pass in the Wiki IDs of two people and return a json of their relationship
+# Pass in the Wiki IDs of two people and return a json of their relationship, common ancestor and path between them
 @app.route("/relationship", methods=["GET"])
 def relationship_calculator():
     id1 = request.args.get("id1", default="", type=str)
     id2 = request.args.get("id2", default="", type=str)
     
     db = Neo4jDB.instance()
-    relationship = RelationshipCalculator.calculate_relationship(db, id1, id2)
+    relationship, common_ancestor, path = RelationshipCalculator.calculate_relationship(db, id1, id2)
     db.close()
 
-    result = {"relationship": relationship}
+    result = {"relationship": relationship, "ancestor": common_ancestor, "path": path}
 
     try:
         response = jsonify(result)


### PR DESCRIPTION
JIRA Link: [HIS-98](https://histree.atlassian.net/jira/software/projects/HIS/boards/1?selectedIssue=HIS-98)

Updates the `/relationship?id1=id1&id2=id2` API endpoint.
Now returns the three following things in a JSON:
- `ancestor`: the ID of one of the least common ancestors (there are often 2)
- `path`: the list of IDs in a shortest path between `id1` and `id2`
- `relationship`: the named relationship between the two people as before

Example usage:
`/relationship?id1=Q165657&id2=Q680304`
> `{"ancestor":"Q80976","path":["Q165657","Q153330","Q80976","Q154920","Q680304"],"relationship":"first cousin"}`

In case the API is used with people with no shortest path within 10 PARENT_OF relations, the following output is returned
> `{"relationship": "has no close relationship with", "ancestor": "no ancestor", "path": []}`

