### PR TITLE
His 107 make tree generation consistent

### DIFF
--- a/histree_backend/data_retrieval/wikitree/tree.py
+++ b/histree_backend/data_retrieval/wikitree/tree.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 import requests
 import json
 from json import JSONDecodeError
-from typing import Dict, List, Tuple
+from typing import Dict, List, Set, Tuple
 from data_retrieval.query.parser import WikiResult, DBResult
 from data_retrieval.wikitree.flower import (
     WikiFlower,
@@ -87,26 +87,24 @@ class WikiSeed:
                         tree.branches[parent_id] = set()
                     tree.branches[parent_id].add(child.id)
 
-        # Find information about parents not in tree
-        if unseen_parent_ids:
-            self.sprout(list(unseen_parent_ids), tree)
-
         unseen_spouse_ids = set()
         # If one ID is an entry point, all IDs must also be entry points
         spouses_only_for_storage = ids and not tree.flowers[ids[0]]._is_entry_point
 
-        # Add spouses without children
-        # Note: no need to check in unseen_parent_ids as they are now in the tree
         for id in ids:
             unseen_spouse_ids.update(
                 spouse
                 for spouse in tree.flowers[id].petals.get("spouse", [])
-                if spouse not in tree.flowers
+                if spouse not in tree.flowers and spouse not in unseen_parent_ids
             )
 
-        if unseen_spouse_ids:
+        # Unseen ids include all spouses but only those without children are for storage
+        unseen_ids = unseen_spouse_ids.union(unseen_parent_ids)
+        if unseen_ids:
             self.sprout(
-                list(unseen_spouse_ids), tree, for_storage=spouses_only_for_storage
+                list(unseen_ids),
+                tree,
+                storage_only=(unseen_spouse_ids if spouses_only_for_storage else set()),
             )
 
         for child in children:
@@ -122,14 +120,14 @@ class WikiSeed:
         ids: List[str],
         tree: "WikiTree",
         is_entry_point: bool = False,
-        for_storage: bool = False,
+        storage_only: Set[str] = set(),
     ) -> List[WikiFlower]:
         flowers = tree.watering(ids, find_flowers, self.self_stem.get_query, False)
 
         for flower in flowers:
             tree.flowers[flower.id] = flower
             flower._is_entry_point = is_entry_point
-            flower._for_storage = for_storage
+            flower._for_storage = flower.id in storage_only
 
         return flowers
 


### PR DESCRIPTION
JIRA Link: [HIS-107](https://histree.atlassian.net/browse/HIS-107?atlOrigin=eyJpIjoiNWU4NWY2NWY0YTMzNDQ5NWJiNWJiN2IwZjZkYzZjNzQiLCJwIjoiaiJ9)

# Description

- Followed up certain requests returning a 429 (Too Many Requests) response.
  - This fixes the inconsistent tree generation dependent on the number of outgoing server requests.
- Included a `User-Agent` header for requests [as advised](https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual#Query_limits). 
- Combined two SPARQL requests (one for archival purposes and another for the tree) into one for efficiency.

# Notes

- A large volume of requests can still lead to 429's but now with less risk of permanent bans (having complied to the User-Agent policy).
  - A task queue can be used to handle this. I'm thinking: one queue for name searches (with two workers) and another for tree generation (one worker). The only caveat is that users will have to wait in queue for trees potentially in the database already.
  - Alternatively, we can make a finer-grained queue with the Wikidata API requests. Regardless of if we're searching for names, expanding on someone's information, or looking for someone's parents, they all wait in queue. Database requests are done separately so they are run without conflict.
    - Here, several scheduling algorithms can be explored. A good strategy could be to keep name searches fast whilst being fair to those generating trees.
